### PR TITLE
feat: add interactive building signage

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,48 +1,390 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>It's a Dog's Life</title>
-  <script src="https://cdn.jsdelivr.net/npm/phaser@3/dist/phaser.js"></script>
+  <style>
+    html, body {
+      margin: 0;
+      padding: 0;
+      height: 100%;
+      overflow: hidden;
+      font-family: "Trebuchet MS", "Gill Sans", sans-serif;
+      background: #1a1a1a;
+    }
+
+    canvas {
+      display: block;
+    }
+
+    #hud {
+      position: fixed;
+      top: 1.5rem;
+      left: 50%;
+      transform: translateX(-50%);
+      padding: 0.75rem 1.5rem;
+      border-radius: 999px;
+      background: rgba(0, 0, 0, 0.55);
+      color: #fff;
+      text-align: center;
+      font-size: 0.95rem;
+      letter-spacing: 0.03em;
+      box-shadow: 0 0.75rem 2rem rgba(0, 0, 0, 0.45);
+      user-select: none;
+      pointer-events: none;
+    }
+
+    #prompt,
+    #signMessage {
+      position: fixed;
+      left: 50%;
+      transform: translateX(-50%);
+      padding: 0.6rem 1.2rem;
+      border-radius: 0.75rem;
+      background: rgba(0, 0, 0, 0.65);
+      color: #fff;
+      text-align: center;
+      font-size: 0.9rem;
+      letter-spacing: 0.02em;
+      opacity: 0;
+      transition: opacity 0.2s ease;
+      pointer-events: none;
+      max-width: 80vw;
+    }
+
+    #prompt {
+      bottom: 4.5rem;
+    }
+
+    #signMessage {
+      bottom: 2rem;
+    }
+
+    #prompt.visible,
+    #signMessage.visible {
+      opacity: 1;
+    }
+  </style>
+  <script type="importmap">
+    {
+      "imports": {
+        "three": "https://unpkg.com/three@0.160.0/build/three.module.js",
+        "three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/"
+      }
+    }
+  </script>
 </head>
 <body>
-<script>
-  const config = {
-    type: Phaser.AUTO,
-    width: 800,
-    height: 600,
-    backgroundColor: '#87ceeb',
-    physics: {
-      default: 'arcade',
-      arcade: { debug: false }
-    },
-    scene: { preload, create, update }
-  };
+  <canvas id="scene"></canvas>
+  <div id="hud">
+    Use WASD or arrow keys to move your handler around the show grounds. Press Enter near a
+    sign to read it.
+  </div>
+  <div id="prompt"></div>
+  <div id="signMessage"></div>
+  <script type="module">
+    import * as THREE from 'three';
 
-  let player;
-  let cursors;
+    const canvas = document.getElementById('scene');
+    const renderer = new THREE.WebGLRenderer({ canvas, antialias: true });
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+    renderer.shadowMap.enabled = true;
 
-  const game = new Phaser.Game(config);
+    const scene = new THREE.Scene();
+    scene.background = new THREE.Color(0x87ceeb);
 
-  function preload() {}
+    const aspect = window.innerWidth / window.innerHeight;
+    const cameraSize = 75;
+    const camera = new THREE.OrthographicCamera(
+      -cameraSize * aspect,
+      cameraSize * aspect,
+      cameraSize,
+      -cameraSize,
+      0.1,
+      1000
+    );
+    const cameraHeight = 120;
+    camera.position.set(0, cameraHeight, 0);
+    camera.lookAt(new THREE.Vector3(0, 0, 0));
 
-  function create() {
-    player = this.add.rectangle(400, 300, 40, 40, 0xff0000);
-    this.physics.add.existing(player);
-    player.body.setCollideWorldBounds(true);
+    const ambient = new THREE.AmbientLight(0xffffff, 0.85);
+    scene.add(ambient);
 
-    cursors = this.input.keyboard.createCursorKeys();
-  }
+    const sun = new THREE.DirectionalLight(0xffffff, 0.65);
+    sun.position.set(80, 150, 100);
+    sun.castShadow = true;
+    sun.shadow.mapSize.set(1024, 1024);
+    scene.add(sun);
 
-  function update() {
-    player.body.setVelocity(0);
+    const groundSize = 220;
+    const ground = new THREE.Mesh(
+      new THREE.PlaneGeometry(groundSize, groundSize),
+      new THREE.MeshLambertMaterial({ color: 0x2d6a4f })
+    );
+    ground.rotation.x = -Math.PI / 2;
+    ground.receiveShadow = true;
+    scene.add(ground);
 
-    if (cursors.left.isDown) player.body.setVelocityX(-200);
-    else if (cursors.right.isDown) player.body.setVelocityX(200);
+    // Show ring - a sandy arena in the middle.
+    const showRing = new THREE.Mesh(
+      new THREE.CircleGeometry(38, 48),
+      new THREE.MeshLambertMaterial({ color: 0xd6a561 })
+    );
+    showRing.rotation.x = -Math.PI / 2;
+    showRing.position.set(0, 0.01, 0);
+    showRing.receiveShadow = true;
+    scene.add(showRing);
 
-    if (cursors.up.isDown) player.body.setVelocityY(-200);
-    else if (cursors.down.isDown) player.body.setVelocityY(200);
-  }
-</script>
+    // Pathways
+    const pathMaterial = new THREE.MeshLambertMaterial({ color: 0xb5b0a1 });
+    const mainPath = new THREE.Mesh(
+      new THREE.PlaneGeometry(30, groundSize),
+      pathMaterial
+    );
+    mainPath.rotation.x = -Math.PI / 2;
+    mainPath.position.set(-60, 0.02, 0);
+    scene.add(mainPath);
+
+    const crossPath = new THREE.Mesh(
+      new THREE.PlaneGeometry(groundSize, 28),
+      pathMaterial
+    );
+    crossPath.rotation.x = -Math.PI / 2;
+    crossPath.position.set(0, 0.02, 60);
+    scene.add(crossPath);
+
+    function createHouse(position, color = 0xf7ede2) {
+      const group = new THREE.Group();
+
+      const houseBase = new THREE.Mesh(
+        new THREE.BoxGeometry(20, 14, 20),
+        new THREE.MeshLambertMaterial({ color })
+      );
+      houseBase.castShadow = true;
+      houseBase.receiveShadow = true;
+      houseBase.position.y = 7;
+      group.add(houseBase);
+
+      const roof = new THREE.Mesh(
+        new THREE.ConeGeometry(16, 10, 4),
+        new THREE.MeshLambertMaterial({ color: 0xc44536 })
+      );
+      roof.castShadow = true;
+      roof.position.y = 7 + 5;
+      roof.rotation.y = Math.PI / 4;
+      group.add(roof);
+
+      const doorway = new THREE.Mesh(
+        new THREE.BoxGeometry(5, 7, 1.5),
+        new THREE.MeshLambertMaterial({ color: 0x1d3557 })
+      );
+      doorway.position.set(0, 3, 10.5);
+      doorway.castShadow = true;
+      group.add(doorway);
+
+      group.position.copy(position);
+      return group;
+    }
+
+    const housePositions = [
+      new THREE.Vector3(-100, 0, -80),
+      new THREE.Vector3(-60, 0, -120),
+      new THREE.Vector3(-120, 0, 40),
+      new THREE.Vector3(100, 0, -90),
+      new THREE.Vector3(70, 0, 80),
+      new THREE.Vector3(20, 0, 110)
+    ];
+
+    housePositions.forEach((pos, index) => {
+      const colorPalette = [0xf7ede2, 0xf1dca7, 0xffddd2];
+      const house = createHouse(pos, colorPalette[index % colorPalette.length]);
+      scene.add(house);
+    });
+
+    function createSign(position) {
+      const signGroup = new THREE.Group();
+
+      const post = new THREE.Mesh(
+        new THREE.CylinderGeometry(0.8, 1.2, 12, 12),
+        new THREE.MeshLambertMaterial({ color: 0x8d5524 })
+      );
+      post.castShadow = true;
+      post.position.y = 6;
+      signGroup.add(post);
+
+      const signBoard = new THREE.Mesh(
+        new THREE.BoxGeometry(8, 4, 1),
+        new THREE.MeshLambertMaterial({ color: 0xfff3b0 })
+      );
+      signBoard.castShadow = true;
+      signBoard.position.set(0, 10, 0.5);
+      signGroup.add(signBoard);
+
+      signGroup.position.copy(position);
+      return signGroup;
+    }
+
+    const signDetails = [
+      {
+        title: 'Home',
+        message: 'Welcome home! Take a moment to rest before the next show.',
+        position: housePositions[0].clone().add(new THREE.Vector3(0, 0, 18))
+      },
+      {
+        title: 'Pet Store',
+        message: 'Stock up on treats, toys, and pampering essentials.',
+        position: housePositions[1].clone().add(new THREE.Vector3(0, 0, 18))
+      },
+      {
+        title: 'Veterinarian',
+        message: 'The best care in town for every champion pup.',
+        position: housePositions[2].clone().add(new THREE.Vector3(0, 0, 18))
+      },
+      {
+        title: 'Dog Groomers',
+        message: 'Fresh trims, shining coats, and wagging tails guaranteed.',
+        position: housePositions[3].clone().add(new THREE.Vector3(0, 0, 18))
+      },
+      {
+        title: 'Dog Club',
+        message: 'Meet fellow handlers and share training tips over coffee.',
+        position: housePositions[4].clone().add(new THREE.Vector3(0, 0, 18))
+      },
+      {
+        title: 'Showground',
+        message: 'Where legends are made and ribbons are won.',
+        position: housePositions[5].clone().add(new THREE.Vector3(0, 0, 18))
+      }
+    ];
+
+    const signs = signDetails.map((detail) => {
+      const sign = createSign(detail.position);
+      scene.add(sign);
+      return { ...detail, mesh: sign };
+    });
+
+    const promptEl = document.getElementById('prompt');
+    const signMessageEl = document.getElementById('signMessage');
+    let signMessageTimeout;
+    let nearbySign = null;
+
+    // Player handler marker
+    const handler = new THREE.Group();
+
+    const handlerBase = new THREE.Mesh(
+      new THREE.CylinderGeometry(4, 4, 4, 24),
+      new THREE.MeshLambertMaterial({ color: 0xffbe0b })
+    );
+    handlerBase.castShadow = true;
+    handlerBase.position.y = 2;
+    handler.add(handlerBase);
+
+    const handlerHead = new THREE.Mesh(
+      new THREE.SphereGeometry(2.6, 24, 24),
+      new THREE.MeshLambertMaterial({ color: 0xf4a261 })
+    );
+    handlerHead.castShadow = true;
+    handlerHead.position.y = 5.3;
+    handler.add(handlerHead);
+
+    handler.position.set(-60, 0, 0);
+    scene.add(handler);
+
+    const keys = new Set();
+    window.addEventListener('keydown', (event) => {
+      keys.add(event.code);
+
+      if (event.code === 'Enter' && !event.repeat && nearbySign) {
+        signMessageEl.textContent = `${nearbySign.title}: ${nearbySign.message}`;
+        signMessageEl.classList.add('visible');
+        clearTimeout(signMessageTimeout);
+        signMessageTimeout = setTimeout(() => {
+          signMessageEl.classList.remove('visible');
+          signMessageEl.textContent = '';
+        }, 4000);
+      }
+    });
+
+    window.addEventListener('keyup', (event) => {
+      keys.delete(event.code);
+    });
+
+    const clock = new THREE.Clock();
+    const movementSpeed = 35;
+    const bounds = {
+      minX: -groundSize / 2 + 10,
+      maxX: groundSize / 2 - 10,
+      minZ: -groundSize / 2 + 10,
+      maxZ: groundSize / 2 - 10
+    };
+
+    function handleMovement(delta) {
+      let moveX = 0;
+      let moveZ = 0;
+
+      if (keys.has('ArrowUp') || keys.has('KeyW')) moveZ -= 1;
+      if (keys.has('ArrowDown') || keys.has('KeyS')) moveZ += 1;
+      if (keys.has('ArrowLeft') || keys.has('KeyA')) moveX -= 1;
+      if (keys.has('ArrowRight') || keys.has('KeyD')) moveX += 1;
+
+      const direction = new THREE.Vector3(moveX, 0, moveZ);
+      if (direction.lengthSq() > 0) {
+        direction.normalize();
+        handler.position.addScaledVector(direction, movementSpeed * delta);
+        handler.position.x = THREE.MathUtils.clamp(handler.position.x, bounds.minX, bounds.maxX);
+        handler.position.z = THREE.MathUtils.clamp(handler.position.z, bounds.minZ, bounds.maxZ);
+
+        handler.rotation.y = Math.atan2(direction.x, direction.z);
+      }
+    }
+
+    function animate() {
+      requestAnimationFrame(animate);
+      const delta = clock.getDelta();
+      handleMovement(delta);
+
+      nearbySign = null;
+      let closestDistance = Infinity;
+      signs.forEach((sign) => {
+        const distance = handler.position.distanceTo(sign.position);
+        if (distance < closestDistance) {
+          closestDistance = distance;
+          nearbySign = sign;
+        }
+      });
+
+      const interactDistance = 22;
+      if (nearbySign && closestDistance <= interactDistance) {
+        promptEl.textContent = `Press Enter to read the ${nearbySign.title} sign.`;
+        promptEl.classList.add('visible');
+      } else {
+        nearbySign = null;
+        promptEl.textContent = '';
+        promptEl.classList.remove('visible');
+      }
+
+      camera.position.x = handler.position.x;
+      camera.position.z = handler.position.z;
+      camera.lookAt(handler.position.x, 0, handler.position.z);
+
+      renderer.render(scene, camera);
+    }
+
+    animate();
+
+    function onResize() {
+      const aspectRatio = window.innerWidth / window.innerHeight;
+      camera.left = -cameraSize * aspectRatio;
+      camera.right = cameraSize * aspectRatio;
+      camera.top = cameraSize;
+      camera.bottom = -cameraSize;
+      camera.updateProjectionMatrix();
+      renderer.setSize(window.innerWidth, window.innerHeight);
+    }
+
+    window.addEventListener('resize', onResize);
+    onResize();
+  </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -187,20 +187,45 @@
       return group;
     }
 
-    const housePositions = [
-      new THREE.Vector3(-100, 0, -80),
-      new THREE.Vector3(-60, 0, -120),
-      new THREE.Vector3(-120, 0, 40),
-      new THREE.Vector3(100, 0, -90),
-      new THREE.Vector3(70, 0, 80),
-      new THREE.Vector3(20, 0, 110)
+    const buildingColorPalette = [0xf7ede2, 0xf1dca7, 0xffddd2];
+    const buildings = [
+      {
+        name: 'Home',
+        message: 'Welcome home! Take a moment to rest before the next show.',
+        position: new THREE.Vector3(-100, 0, -80),
+        signOffset: new THREE.Vector3(0, 0, 18)
+      },
+      {
+        name: 'Pet Store',
+        message: 'Stock up on treats, toys, and pampering essentials.',
+        position: new THREE.Vector3(-60, 0, -120),
+        signOffset: new THREE.Vector3(0, 0, 18)
+      },
+      {
+        name: 'Veterinarian',
+        message: 'The best care in town for every champion pup.',
+        position: new THREE.Vector3(-120, 0, 40),
+        signOffset: new THREE.Vector3(0, 0, 18)
+      },
+      {
+        name: 'Dog Groomers',
+        message: 'Fresh trims, shining coats, and wagging tails guaranteed.',
+        position: new THREE.Vector3(100, 0, -90),
+        signOffset: new THREE.Vector3(0, 0, 18)
+      },
+      {
+        name: 'Dog Club',
+        message: 'Meet fellow handlers and share training tips over coffee.',
+        position: new THREE.Vector3(70, 0, 80),
+        signOffset: new THREE.Vector3(0, 0, 18)
+      },
+      {
+        name: 'Showground',
+        message: 'Where legends are made and ribbons are won.',
+        position: new THREE.Vector3(20, 0, 110),
+        signOffset: new THREE.Vector3(0, 0, 18)
+      }
     ];
-
-    housePositions.forEach((pos, index) => {
-      const colorPalette = [0xf7ede2, 0xf1dca7, 0xffddd2];
-      const house = createHouse(pos, colorPalette[index % colorPalette.length]);
-      scene.add(house);
-    });
 
     function createSign(position) {
       const signGroup = new THREE.Group();
@@ -225,48 +250,21 @@
       return signGroup;
     }
 
-    const signDetails = [
-      {
-        title: 'Home',
-        message: 'Welcome home! Take a moment to rest before the next show.',
-        position: housePositions[0].clone().add(new THREE.Vector3(0, 0, 18))
-      },
-      {
-        title: 'Pet Store',
-        message: 'Stock up on treats, toys, and pampering essentials.',
-        position: housePositions[1].clone().add(new THREE.Vector3(0, 0, 18))
-      },
-      {
-        title: 'Veterinarian',
-        message: 'The best care in town for every champion pup.',
-        position: housePositions[2].clone().add(new THREE.Vector3(0, 0, 18))
-      },
-      {
-        title: 'Dog Groomers',
-        message: 'Fresh trims, shining coats, and wagging tails guaranteed.',
-        position: housePositions[3].clone().add(new THREE.Vector3(0, 0, 18))
-      },
-      {
-        title: 'Dog Club',
-        message: 'Meet fellow handlers and share training tips over coffee.',
-        position: housePositions[4].clone().add(new THREE.Vector3(0, 0, 18))
-      },
-      {
-        title: 'Showground',
-        message: 'Where legends are made and ribbons are won.',
-        position: housePositions[5].clone().add(new THREE.Vector3(0, 0, 18))
-      }
-    ];
+    const signs = buildings.map((building, index) => {
+      const houseColor = buildingColorPalette[index % buildingColorPalette.length];
+      const house = createHouse(building.position, houseColor);
+      scene.add(house);
 
-    const signs = signDetails.map((detail) => {
-      const sign = createSign(detail.position);
+      const signPosition = building.position.clone().add(building.signOffset);
+      const sign = createSign(signPosition);
       scene.add(sign);
-      return { ...detail, mesh: sign };
+
+      return { title: building.name, message: building.message, mesh: sign };
     });
 
     const promptEl = document.getElementById('prompt');
     const signMessageEl = document.getElementById('signMessage');
-    let signMessageTimeout;
+    let signMessageTimeout = null;
     let nearbySign = null;
 
     // Player handler marker
@@ -292,17 +290,31 @@
     scene.add(handler);
 
     const keys = new Set();
+    function showSignMessage(sign) {
+      signMessageEl.textContent = `${sign.title}: ${sign.message}`;
+      signMessageEl.classList.add('visible');
+      clearTimeout(signMessageTimeout);
+      signMessageTimeout = setTimeout(() => {
+        hideSignMessage();
+      }, 4000);
+    }
+
+    function hideSignMessage() {
+      signMessageEl.classList.remove('visible');
+      signMessageEl.textContent = '';
+      clearTimeout(signMessageTimeout);
+      signMessageTimeout = null;
+    }
+
     window.addEventListener('keydown', (event) => {
       keys.add(event.code);
 
       if (event.code === 'Enter' && !event.repeat && nearbySign) {
-        signMessageEl.textContent = `${nearbySign.title}: ${nearbySign.message}`;
-        signMessageEl.classList.add('visible');
-        clearTimeout(signMessageTimeout);
-        signMessageTimeout = setTimeout(() => {
-          signMessageEl.classList.remove('visible');
-          signMessageEl.textContent = '';
-        }, 4000);
+        showSignMessage(nearbySign);
+      }
+
+      if (event.code === 'Escape') {
+        hideSignMessage();
       }
     });
 
@@ -347,7 +359,7 @@
       nearbySign = null;
       let closestDistance = Infinity;
       signs.forEach((sign) => {
-        const distance = handler.position.distanceTo(sign.position);
+        const distance = handler.position.distanceTo(sign.mesh.position);
         if (distance < closestDistance) {
           closestDistance = distance;
           nearbySign = sign;
@@ -362,6 +374,7 @@
         nearbySign = null;
         promptEl.textContent = '';
         promptEl.classList.remove('visible');
+        hideSignMessage();
       }
 
       camera.position.x = handler.position.x;


### PR DESCRIPTION
## Summary
- add signposts next to each building in the show grounds
- display contextual prompts and sign messages when the handler interacts with signs
- style HUD overlays for interaction prompts and messages

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d845c21730832fb0833396bea2bd1d