### PR TITLE
Modularize level designer and add interior mode

### DIFF
--- a/js/leveldesigner/main.js
+++ b/js/leveldesigner/main.js
@@ -1,0 +1,468 @@
+import { DESIGN_MODES, TILE_SIZE, BRUSH_OPTIONS, DEFAULT_GRID_SIZE, GRID_LIMITS } from './modes.js';
+import { createGrid, cloneGrid } from './state.js';
+import { updateTileAppearance } from './rendering.js';
+import { applyBrush } from './tools.js';
+
+const toolList = document.getElementById('toolList');
+const brushContainer = document.getElementById('brushOptions');
+const gridElement = document.getElementById('grid');
+const statusElement = document.getElementById('status');
+const tileTemplate = document.getElementById('tileTemplate');
+const gridSizeInput = document.getElementById('gridSize');
+const signInput = document.getElementById('signText');
+const resizeButton = document.getElementById('resizeGrid');
+const downloadButton = document.getElementById('downloadJson');
+const loadButton = document.getElementById('loadJson');
+const loadInput = document.getElementById('loadJsonInput');
+const openLevelButton = document.getElementById('openLevel');
+const designerTitle = document.getElementById('designerTitle');
+const designerTagline = document.getElementById('designerTagline');
+const modeSelect = document.getElementById('modeSelect');
+const signLegend = document.getElementById('signLegend');
+const signLabel = document.getElementById('signLabel');
+const signHint = document.getElementById('signHint');
+
+const modeSnapshots = new Map();
+const tileElements = [];
+const toolButtons = new Map();
+const brushButtons = new Map();
+
+let currentMode = DESIGN_MODES.town || Object.values(DESIGN_MODES)[0];
+let gridSize = DEFAULT_GRID_SIZE;
+let state = createGrid(DEFAULT_GRID_SIZE, currentMode.defaultTile);
+let currentTool = currentMode.defaultTool;
+let brushDimension = BRUSH_OPTIONS[0];
+let currentSignText = '';
+let mouseDown = false;
+
+function ensureSnapshot(mode) {
+  if (!modeSnapshots.has(mode.id)) {
+    modeSnapshots.set(mode.id, {
+      gridSize: DEFAULT_GRID_SIZE,
+      state: createGrid(DEFAULT_GRID_SIZE, mode.defaultTile),
+      toolId: mode.defaultTool,
+      brushSize: BRUSH_OPTIONS[0],
+      signText: ''
+    });
+  }
+  return modeSnapshots.get(mode.id);
+}
+
+function saveActiveSnapshot() {
+  const snapshot = ensureSnapshot(currentMode);
+  snapshot.gridSize = gridSize;
+  snapshot.state = state;
+  snapshot.toolId = currentTool;
+  snapshot.brushSize = brushDimension;
+  snapshot.signText = currentSignText;
+}
+
+function onTileUpdated(x, y) {
+  const row = tileElements[y];
+  const element = row && row[x];
+  if (!element) return;
+  updateTileAppearance({ element, tile: state[y][x], x, y, mode: currentMode, state, gridSize });
+}
+
+function renderGrid() {
+  gridElement.innerHTML = '';
+  tileElements.length = 0;
+  gridElement.style.setProperty('--tile-size', `${TILE_SIZE}px`);
+  gridElement.style.gridTemplateColumns = `repeat(${gridSize}, ${TILE_SIZE}px)`;
+  gridElement.style.gridTemplateRows = `repeat(${gridSize}, ${TILE_SIZE}px)`;
+  gridElement.style.width = `${gridSize * TILE_SIZE}px`;
+  gridElement.style.height = `${gridSize * TILE_SIZE}px`;
+
+  for (let y = 0; y < gridSize; y++) {
+    tileElements[y] = [];
+    for (let x = 0; x < gridSize; x++) {
+      const tileState = state[y][x];
+      const tile = tileTemplate.content.firstElementChild.cloneNode(true);
+      tile.dataset.x = x;
+      tile.dataset.y = y;
+      tile.addEventListener('pointerdown', handlePointerDown);
+      tile.addEventListener('pointerenter', handlePointerEnter);
+      tile.addEventListener('contextmenu', event => event.preventDefault());
+      tileElements[y][x] = tile;
+      updateTileAppearance({ element: tile, tile: tileState, x, y, mode: currentMode, state, gridSize });
+      gridElement.appendChild(tile);
+    }
+  }
+}
+
+function setActiveTool(toolId) {
+  if (!currentMode.toolsById.has(toolId)) {
+    toolId = currentMode.defaultTool;
+  }
+  currentTool = toolId;
+  toolButtons.forEach((button, id) => {
+    button.classList.toggle('active', id === currentTool);
+  });
+  const tool = currentMode.toolsById.get(currentTool);
+  if (tool) {
+    updateStatus(`Selected ${tool.label}. ${tool.description}`);
+  }
+  ensureSnapshot(currentMode).toolId = currentTool;
+}
+
+function renderPalette() {
+  toolButtons.clear();
+  toolList.innerHTML = '';
+  currentMode.palette.forEach(tool => {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'tool';
+    button.dataset.tool = tool.id;
+    button.innerHTML = `<span class="tool-icon">${tool.icon}</span> ${tool.label}`;
+    button.title = tool.description;
+    button.addEventListener('click', () => {
+      setActiveTool(tool.id);
+    });
+    toolButtons.set(tool.id, button);
+    toolList.appendChild(button);
+  });
+  setActiveTool(currentTool);
+}
+
+function setBrushSize(size) {
+  brushDimension = size;
+  brushButtons.forEach((button, value) => {
+    button.classList.toggle('active', value === brushDimension);
+  });
+  updateStatus(`Brush size set to ${size}×${size}.`);
+  ensureSnapshot(currentMode).brushSize = brushDimension;
+}
+
+function renderBrushOptions() {
+  brushButtons.clear();
+  brushContainer.innerHTML = '';
+  BRUSH_OPTIONS.forEach(size => {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'brush';
+    button.dataset.size = size;
+    button.textContent = `${size}×${size}`;
+    button.addEventListener('click', () => setBrushSize(size));
+    brushButtons.set(size, button);
+    brushContainer.appendChild(button);
+  });
+  if (!brushButtons.has(brushDimension)) {
+    brushDimension = BRUSH_OPTIONS[0];
+  }
+  setBrushSize(brushDimension);
+}
+
+function updateStatus(message) {
+  statusElement.textContent = message;
+}
+
+function handlePointerDown(event) {
+  event.preventDefault();
+  const toolId = event.button === 2 ? 'sea' : currentTool;
+  const x = Number(event.currentTarget.dataset.x);
+  const y = Number(event.currentTarget.dataset.y);
+  mouseDown = true;
+  applyBrush({
+    mode: currentMode,
+    state,
+    gridSize,
+    x,
+    y,
+    toolId,
+    brushSize: brushDimension,
+    onTileUpdated,
+    updateStatus,
+    signText: currentSignText
+  });
+  window.addEventListener('pointerup', handlePointerUp, { once: true });
+}
+
+function handlePointerEnter(event) {
+  if (!mouseDown) return;
+  const toolId = event.buttons === 2 ? 'sea' : currentTool;
+  const x = Number(event.currentTarget.dataset.x);
+  const y = Number(event.currentTarget.dataset.y);
+  applyBrush({
+    mode: currentMode,
+    state,
+    gridSize,
+    x,
+    y,
+    toolId,
+    brushSize: brushDimension,
+    onTileUpdated,
+    updateStatus,
+    signText: currentSignText
+  });
+}
+
+function handlePointerUp() {
+  mouseDown = false;
+}
+
+function resizeGrid() {
+  const requested = Number(gridSizeInput.value);
+  if (!Number.isInteger(requested) || requested < GRID_LIMITS.min || requested > GRID_LIMITS.max) {
+    updateStatus(currentMode.messages.gridInvalid);
+    return;
+  }
+  const snapshot = ensureSnapshot(currentMode);
+  snapshot.gridSize = requested;
+  snapshot.state = createGrid(requested, currentMode.defaultTile);
+  state = snapshot.state;
+  gridSize = snapshot.gridSize;
+  renderGrid();
+  updateStatus(currentMode.messages.resized(requested));
+}
+
+function exportJson() {
+  const layout = {
+    mode: currentMode.id,
+    size: gridSize,
+    tiles: cloneGrid(state)
+  };
+  const blob = new Blob([JSON.stringify(layout, null, 2)], { type: 'application/json' });
+  const link = document.createElement('a');
+  link.href = URL.createObjectURL(blob);
+  link.download = currentMode.layoutFileName;
+  link.click();
+  URL.revokeObjectURL(link.href);
+}
+
+function loadJsonFromFile(file) {
+  const reader = new FileReader();
+  reader.addEventListener('load', () => {
+    try {
+      const parsed = JSON.parse(reader.result);
+      applyLayout(parsed);
+      updateStatus(currentMode.messages.loadSuccess(file.name));
+    } catch (error) {
+      console.error('Failed to load layout', error);
+      const message = error instanceof Error ? error.message : 'Invalid JSON file.';
+      updateStatus(`Unable to load layout: ${message}`);
+    }
+  });
+  reader.readAsText(file);
+}
+
+function applyLayout(layout) {
+  if (!layout || typeof layout !== 'object') {
+    throw new Error('Layout must be an object.');
+  }
+  const modeId = layout.mode && DESIGN_MODES[layout.mode] ? layout.mode : currentMode.id;
+  if (modeId !== currentMode.id) {
+    setDesignMode(modeId, { silent: true });
+  }
+  const size = Number(layout.size);
+  if (!Number.isInteger(size) || size < GRID_LIMITS.min || size > GRID_LIMITS.max) {
+    throw new Error('Layout size out of bounds.');
+  }
+  const tiles = layout.tiles;
+  if (!Array.isArray(tiles) || tiles.length !== size) {
+    throw new Error('Tiles array does not match layout size.');
+  }
+
+  const sanitized = createGrid(size, currentMode.defaultTile);
+  for (let y = 0; y < size; y++) {
+    const row = tiles[y];
+    if (!Array.isArray(row) || row.length !== size) {
+      throw new Error('Tile rows must match layout size.');
+    }
+    for (let x = 0; x < size; x++) {
+      sanitized[y][x] = currentMode.sanitizeTile(row[x]);
+    }
+  }
+
+  const snapshot = ensureSnapshot(currentMode);
+  snapshot.gridSize = size;
+  snapshot.state = sanitized;
+  state = snapshot.state;
+  gridSize = size;
+  gridSizeInput.value = size;
+  renderGrid();
+  mouseDown = false;
+}
+
+function generateLevelHtml() {
+  const snapshot = state.map(row => row.map(tile => ({ base: tile.base, overlay: tile.overlay, signText: tile.signText })));
+  const data = {
+    modeId: currentMode.id,
+    layout: { size: gridSize, tiles: snapshot },
+    preview: currentMode.preview
+  };
+  const serialized = JSON.stringify(data).replace(/</g, '\\u003c');
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>${currentMode.preview.documentTitle}</title>
+  <style>
+    :root { color-scheme: dark; }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: grid;
+      place-items: center;
+      font-family: "Segoe UI", system-ui, sans-serif;
+      color: #eef5ff;
+    }
+    main {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 1rem;
+    }
+    .map {
+      --tile-size: ${TILE_SIZE}px;
+      display: grid;
+      gap: 0;
+      background: rgba(4, 20, 34, 0.85);
+      padding: 0.75rem;
+      border-radius: 1.2rem;
+      box-shadow: 0 1.5rem 3.5rem rgba(0, 0, 0, 0.4);
+    }
+    .cell {
+      width: var(--tile-size);
+      height: var(--tile-size);
+      position: relative;
+      background-repeat: no-repeat;
+      background-origin: border-box;
+      display: grid;
+      place-items: center;
+      font-size: calc(var(--tile-size) * 0.5);
+    }
+    .cell::after {
+      content: attr(data-overlay-symbol);
+      position: absolute;
+      inset: 0;
+      display: grid;
+      place-items: center;
+      font-size: calc(var(--tile-size) * 0.5);
+      color: #fff9c4;
+      text-shadow: 0 1px 2px rgba(0, 0, 0, 0.6);
+      pointer-events: none;
+    }
+    .cell[data-overlay="sign"]::after {
+      font-size: calc(var(--tile-size) * 0.4);
+      font-weight: 600;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+    }
+    footer {
+      font-size: 0.9rem;
+      color: rgba(238, 245, 255, 0.7);
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <h1 id="previewTitle"></h1>
+    <section id="map" class="map" role="grid" aria-label="Level layout"></section>
+    <footer id="previewFooter"></footer>
+  </main>
+  <script>window.__LEVEL_DATA__ = ${serialized};</script>
+  <script type="module" src="./js/leveldesigner/preview-runtime.js"></script>
+</body>
+</html>`;
+}
+
+function openLevelPage() {
+  const levelHtml = generateLevelHtml();
+  const levelWindow = window.open('', '_blank');
+  if (!levelWindow) {
+    updateStatus('Pop-up blocked. Allow pop-ups to open the level page.');
+    return;
+  }
+  levelWindow.document.write(levelHtml);
+  levelWindow.document.close();
+}
+
+function updateSignUi() {
+  const section = currentMode.signSection;
+  signLegend.textContent = section.legend;
+  signLabel.textContent = section.label;
+  signHint.textContent = section.hint;
+  signInput.placeholder = section.placeholder;
+  signInput.maxLength = currentMode.signMaxLength;
+}
+
+function updateModeUi() {
+  designerTitle.textContent = currentMode.title;
+  document.title = currentMode.title;
+  designerTagline.textContent = currentMode.tagline;
+  gridSizeInput.value = gridSize;
+  updateSignUi();
+}
+
+function setDesignMode(modeId, { silent = false } = {}) {
+  const nextMode = DESIGN_MODES[modeId];
+  if (!nextMode) return;
+
+  saveActiveSnapshot();
+
+  currentMode = nextMode;
+  const snapshot = ensureSnapshot(currentMode);
+  gridSize = snapshot.gridSize;
+  state = snapshot.state;
+  currentTool = snapshot.toolId || currentMode.defaultTool;
+  brushDimension = snapshot.brushSize || BRUSH_OPTIONS[0];
+  currentSignText = snapshot.signText || '';
+  signInput.value = currentSignText;
+  modeSelect.value = currentMode.id;
+
+  updateModeUi();
+  renderPalette();
+  renderBrushOptions();
+  renderGrid();
+  if (!silent) {
+    updateStatus(currentMode.instructions);
+  }
+}
+
+function populateModeSelect() {
+  modeSelect.innerHTML = '';
+  Object.values(DESIGN_MODES).forEach(mode => {
+    const option = document.createElement('option');
+    option.value = mode.id;
+    option.textContent = mode.label;
+    modeSelect.appendChild(option);
+  });
+  modeSelect.value = currentMode.id;
+}
+
+function initialize() {
+  populateModeSelect();
+  setDesignMode(currentMode.id, { silent: true });
+  updateStatus(currentMode.instructions);
+
+  signInput.addEventListener('input', event => {
+    currentSignText = currentMode.normalizeSignText(event.target.value);
+    signInput.value = currentSignText;
+    ensureSnapshot(currentMode).signText = currentSignText;
+  });
+
+  resizeButton.addEventListener('click', resizeGrid);
+  downloadButton.addEventListener('click', exportJson);
+  loadButton.addEventListener('click', () => loadInput.click());
+  loadInput.addEventListener('change', event => {
+    const [file] = event.target.files || [];
+    if (!file) return;
+    const isJsonType = file.type === 'application/json';
+    const isJsonName = file.name?.toLowerCase().endsWith('.json');
+    if (file.type && !isJsonType && !isJsonName) {
+      updateStatus('Please choose a JSON layout file.');
+      event.target.value = '';
+      return;
+    }
+    loadJsonFromFile(file);
+    event.target.value = '';
+  });
+  openLevelButton.addEventListener('click', openLevelPage);
+  modeSelect.addEventListener('change', event => setDesignMode(event.target.value));
+  gridElement.addEventListener('pointerleave', () => {
+    mouseDown = false;
+  });
+}
+
+initialize();

--- a/js/leveldesigner/modes.js
+++ b/js/leveldesigner/modes.js
@@ -1,0 +1,432 @@
+const TILE_SIZE = 32;
+const BRUSH_OPTIONS = [1, 2, 4, 8];
+const DEFAULT_GRID_SIZE = 16;
+const GRID_LIMITS = { min: 6, max: 50 };
+
+const NINE_SLICE_COORDS = {
+  single: { col: 0, row: 1 },
+  topLeft: { col: 2, row: 0 },
+  top: { col: 2, row: 1 },
+  topRight: { col: 2, row: 2 },
+  left: { col: 3, row: 0 },
+  center: { col: 3, row: 1 },
+  right: { col: 3, row: 2 },
+  bottomLeft: { col: 4, row: 0 },
+  bottom: { col: 4, row: 2 },
+  bottomRight: { col: 4, row: 3 }
+};
+
+const SHORT_GRASS_VARIANTS = [
+  { col: 7, row: 0 },
+  { col: 7, row: 1 },
+  { col: 7, row: 2 },
+  { col: 7, row: 3 }
+];
+
+function computeNineSliceKey(x, y, gridSize, matchFn) {
+  const up = matchFn(x, y - 1);
+  const down = matchFn(x, y + 1);
+  const left = matchFn(x - 1, y);
+  const right = matchFn(x + 1, y);
+
+  if (!up && !down && !left && !right) return 'single';
+  if (!up && !left) return 'topLeft';
+  if (!up && !right) return 'topRight';
+  if (!down && !left) return 'bottomLeft';
+  if (!down && !right) return 'bottomRight';
+  if (!up) return 'top';
+  if (!down) return 'bottom';
+  if (!left) return 'left';
+  if (!right) return 'right';
+  return 'center';
+}
+
+function spriteLayer(sheet, frame) {
+  if (!sheet || !frame) return null;
+  const sizeX = sheet.columns * TILE_SIZE;
+  const sizeY = sheet.rows * TILE_SIZE;
+  return {
+    image: `url(${sheet.src})`,
+    size: `${sizeX}px ${sizeY}px`,
+    position: `${-frame.col * TILE_SIZE}px ${-frame.row * TILE_SIZE}px`
+  };
+}
+
+function tintLayer(color) {
+  return { image: `linear-gradient(${color}, ${color})`, size: '100% 100%', position: '0 0' };
+}
+
+function normalizeText(text, maxLength) {
+  if (typeof text !== 'string') return '';
+  return text.slice(0, maxLength).trim();
+}
+
+function createTownMode() {
+  const overlayEmoji = {
+    none: '',
+    grass: '',
+    'short-grass': '',
+    'long-grass': '',
+    path: '',
+    house: '🏠',
+    vets: '🐾',
+    'dog-training': '🎯',
+    'dog-groomers': '✂️',
+    'dog-show': '🏆',
+    'pet-shop': '🛍️',
+    sign: '🪧'
+  };
+
+  const buildingTints = {
+    house: 'rgba(199, 98, 120, 0.72)',
+    vets: 'rgba(70, 140, 180, 0.72)',
+    'dog-training': 'rgba(138, 109, 200, 0.72)',
+    'dog-groomers': 'rgba(200, 90, 150, 0.72)',
+    'dog-show': 'rgba(200, 170, 90, 0.72)',
+    'pet-shop': 'rgba(90, 170, 120, 0.72)'
+  };
+
+  const spriteSheets = {
+    land: { src: 'assets/dirt.png', columns: 8, rows: 8 },
+    path: { src: 'assets/dirt.png', columns: 8, rows: 8 },
+    grass: { src: 'assets/grass.png', columns: 8, rows: 8 },
+    longGrass: { src: 'assets/long-grass.png', columns: 8, rows: 8 },
+    water: { src: 'assets/water.png', columns: 8, rows: 8 }
+  };
+
+  const mode = {
+    id: 'town',
+    label: 'Town Exterior',
+    title: 'Town Level Designer',
+    tagline: 'Left click to paint • Right click to sea',
+    instructions:
+      'Select Land to shape your island, use Grass with larger brushes to fill areas, then add paths, specialist buildings, and custom signs. Right-click turns tiles back into sea.',
+    defaultTool: 'land',
+    signToolId: 'sign',
+    signMaxLength: 32,
+    layoutFileName: 'town-layout.json',
+    requiredBase: 'land',
+    baseLabels: { sea: 'sea', land: 'land' },
+    overlayLabels: {
+      grass: 'grass',
+      'short-grass': 'short grass',
+      'long-grass': 'long grass',
+      path: 'path',
+      house: 'house',
+      vets: 'veterinary clinic',
+      'dog-training': 'dog training grounds',
+      'dog-groomers': 'dog groomers',
+      'dog-show': 'dog show arena',
+      'pet-shop': 'pet shop',
+      sign: 'sign'
+    },
+    overlayEmoji,
+    baseTypes: new Set(['sea', 'land']),
+    overlayTypes: new Set([
+      'none',
+      'grass',
+      'path',
+      'short-grass',
+      'long-grass',
+      'house',
+      'vets',
+      'dog-training',
+      'dog-groomers',
+      'dog-show',
+      'pet-shop',
+      'sign'
+    ]),
+    brushTools: new Set(['land', 'grass', 'short-grass', 'long-grass']),
+    landOnlyTools: new Set([
+      'grass',
+      'short-grass',
+      'long-grass',
+      'path',
+      'house',
+      'vets',
+      'dog-training',
+      'dog-groomers',
+      'dog-show',
+      'pet-shop',
+      'sign'
+    ]),
+    buildingTools: new Set(['house', 'vets', 'dog-training', 'dog-groomers', 'dog-show', 'pet-shop']),
+    buildingSize: 5,
+    buildingTints,
+    spriteSheets,
+    defaultTile: () => ({ base: 'sea', overlay: 'none', signText: '' }),
+    messages: {
+      needsBase: 'Claim land before placing terrain, buildings, or signs.',
+      gridInvalid: 'Grid size must be between 6 and 50.',
+      resized: size => `Grid resized to ${size} × ${size}. Start shaping your land!`,
+      buildingRequirement: (label, size) => `Need a ${size}×${size} land area cleared for ${label}.`,
+      loadSuccess: file => `Loaded layout from ${file}.`
+    },
+    signSection: {
+      legend: 'Sign Writer',
+      label: 'Message',
+      hint: 'Update existing signs by painting them again.',
+      placeholder: 'Welcome adventurers'
+    },
+    preview: {
+      documentTitle: 'Town Level Preview',
+      title: 'Town Level Preview',
+      footer: 'Everything beyond the island edge is open sea and currently inaccessible.',
+      background: 'radial-gradient(circle at top, rgba(120, 180, 255, 0.18), rgba(9, 14, 24, 0.95))'
+    }
+  };
+
+  mode.palette = [
+    { id: 'land', label: 'Land', icon: '🏝️', description: 'Claim land from the surrounding sea.', category: 'base', base: 'land' },
+    { id: 'sea', label: 'Sea', icon: '🌊', description: 'Return a tile to open water.', category: 'base', base: 'sea' },
+    { id: 'grass', label: 'Grass', icon: '🌱', description: 'Add standard grass using the shared tileset.', category: 'overlay', overlay: 'grass', requiresBase: 'land' },
+    { id: 'short-grass', label: 'Short Grass', icon: '🌾', description: 'Trimmed grass variant for tidy areas.', category: 'overlay', overlay: 'short-grass', requiresBase: 'land' },
+    { id: 'long-grass', label: 'Long Grass', icon: '🌿', description: 'Tall grass using the long grass sheet.', category: 'overlay', overlay: 'long-grass', requiresBase: 'land' },
+    { id: 'path', label: 'Path', icon: '🪨', description: 'Lay walking paths for players.', category: 'overlay', overlay: 'path', requiresBase: 'land' },
+    { id: 'house', label: 'House', icon: '🏠', description: 'Place village houses on land.', category: 'building', overlay: 'house' },
+    { id: 'vets', label: 'Vets', icon: '🐾', description: 'Mark veterinary services for pets.', category: 'building', overlay: 'vets' },
+    { id: 'dog-training', label: 'Dog Training', icon: '🎯', description: 'Plan dedicated dog training areas.', category: 'building', overlay: 'dog-training' },
+    { id: 'dog-groomers', label: 'Dog Groomers', icon: '✂️', description: 'Set up grooming parlours for pups.', category: 'building', overlay: 'dog-groomers' },
+    { id: 'dog-show', label: 'Dog Show', icon: '🏆', description: 'Designate the show arena.', category: 'building', overlay: 'dog-show' },
+    { id: 'pet-shop', label: 'Pet Shop', icon: '🛍️', description: 'Place pet supply stores.', category: 'building', overlay: 'pet-shop' },
+    { id: 'sign', label: 'Sign', icon: '🪧', description: 'Add signage for directions or lore.', category: 'sign', requiresBase: 'land' }
+  ];
+
+  mode.toolsById = new Map(mode.palette.map(tool => [tool.id, tool]));
+
+  mode.normalizeSignText = text => normalizeText(text, mode.signMaxLength);
+
+  mode.getOverlaySymbol = tile => {
+    if (tile.overlay === mode.signToolId) {
+      return tile.signText || overlayEmoji[mode.signToolId] || '';
+    }
+    return overlayEmoji[tile.overlay] || '';
+  };
+
+  mode.describeOverlay = tile => {
+    if (tile.overlay === 'none') return '';
+    if (tile.overlay === mode.signToolId) {
+      return tile.signText ? `sign “${tile.signText}”` : 'sign';
+    }
+    return mode.overlayLabels[tile.overlay] || tile.overlay.replace(/-/g, ' ');
+  };
+
+  mode.buildTileLayers = ({ state, gridSize, tile, x, y }) => {
+    const overlayLayers = [];
+
+    const landMatch = (nx, ny) => ny >= 0 && ny < gridSize && nx >= 0 && nx < gridSize && state[ny][nx].base === 'land';
+    const overlayMatch = (nx, ny, overlay) =>
+      ny >= 0 && ny < gridSize && nx >= 0 && nx < gridSize && state[ny][nx].overlay === overlay;
+
+    const getLandFrame = () => {
+      const key = computeNineSliceKey(x, y, gridSize, landMatch);
+      return NINE_SLICE_COORDS[key] || NINE_SLICE_COORDS.center;
+    };
+
+    const getOverlayFrame = overlay => {
+      const key = computeNineSliceKey(x, y, gridSize, (nx, ny) => overlayMatch(nx, ny, overlay));
+      return NINE_SLICE_COORDS[key] || NINE_SLICE_COORDS.center;
+    };
+
+    const getShortGrassFrame = () => {
+      const index = Math.abs((x * 131 + y * 17) % SHORT_GRASS_VARIANTS.length);
+      return SHORT_GRASS_VARIANTS[index];
+    };
+
+    switch (tile.overlay) {
+      case 'grass':
+        overlayLayers.push(spriteLayer(spriteSheets.grass, getOverlayFrame('grass')));
+        break;
+      case 'long-grass':
+        overlayLayers.push(spriteLayer(spriteSheets.longGrass, getOverlayFrame('long-grass')));
+        break;
+      case 'short-grass':
+        overlayLayers.push(spriteLayer(spriteSheets.grass, getShortGrassFrame()));
+        break;
+      case 'path':
+        overlayLayers.push(spriteLayer(spriteSheets.path, getOverlayFrame('path')));
+        break;
+      case 'sign':
+        overlayLayers.push(tintLayer('rgba(150, 98, 45, 0.75)'));
+        break;
+      default:
+        if (buildingTints[tile.overlay]) {
+          overlayLayers.push(tintLayer(buildingTints[tile.overlay]));
+        }
+    }
+
+    const baseLayer =
+      tile.base === 'sea'
+        ? spriteLayer(spriteSheets.water, { col: 0, row: 0 })
+        : spriteLayer(spriteSheets.land, getLandFrame());
+
+    return overlayLayers.filter(Boolean).concat(baseLayer ? [baseLayer] : []);
+  };
+
+  mode.sanitizeTile = tile => {
+    const safeBase = mode.baseTypes.has(tile?.base) ? tile.base : mode.defaultTile().base;
+    let safeOverlay = mode.overlayTypes.has(tile?.overlay) ? tile.overlay : 'none';
+    let safeSign = '';
+
+    if (safeOverlay !== 'none' && safeBase !== mode.requiredBase) {
+      safeOverlay = 'none';
+    }
+
+    if (safeOverlay === mode.signToolId) {
+      safeSign = mode.normalizeSignText(tile?.signText);
+    }
+
+    return {
+      base: safeOverlay === 'none' ? safeBase : mode.requiredBase,
+      overlay: safeOverlay,
+      signText: safeSign
+    };
+  };
+
+  return mode;
+}
+
+function createInteriorMode() {
+  const overlayEmoji = {
+    none: '',
+    carpet: '🟥',
+    'tile-inlay': '🎨',
+    counter: '🪑',
+    kennel: '🐶',
+    sign: '📝'
+  };
+
+  const overlayLabels = {
+    carpet: 'carpet',
+    'tile-inlay': 'tile inlay',
+    counter: 'counter',
+    kennel: 'kennel space',
+    sign: 'note'
+  };
+
+  const mode = {
+    id: 'interior',
+    label: 'Interior',
+    title: 'Interior Level Designer',
+    tagline: 'Left click to paint • Right click to clear',
+    instructions:
+      'Lay down Floor tiles to outline the room, then add carpets, counters, kennels, and notes to plan the interior spaces. Right-click clears tiles back to empty space.',
+    defaultTool: 'land',
+    signToolId: 'sign',
+    signMaxLength: 64,
+    layoutFileName: 'interior-layout.json',
+    requiredBase: 'land',
+    baseLabels: { sea: 'empty space', land: 'floor' },
+    overlayLabels,
+    overlayEmoji,
+    baseTypes: new Set(['sea', 'land']),
+    overlayTypes: new Set(['none', 'carpet', 'tile-inlay', 'counter', 'kennel', 'sign']),
+    brushTools: new Set(['land', 'carpet', 'tile-inlay']),
+    landOnlyTools: new Set(['carpet', 'tile-inlay', 'counter', 'kennel', 'sign']),
+    buildingTools: new Set(),
+    buildingSize: 3,
+    buildingTints: {
+      carpet: 'rgba(180, 70, 90, 0.78)',
+      'tile-inlay': 'rgba(90, 150, 190, 0.78)',
+      counter: 'rgba(180, 150, 110, 0.78)',
+      kennel: 'rgba(140, 110, 80, 0.78)',
+      sign: 'rgba(190, 160, 120, 0.78)'
+    },
+    spriteSheets: {},
+    defaultTile: () => ({ base: 'sea', overlay: 'none', signText: '' }),
+    messages: {
+      needsBase: 'Lay down Floor before placing interior details.',
+      gridInvalid: 'Grid size must be between 6 and 50.',
+      resized: size => `Grid resized to ${size} × ${size}. Sketch a new floor plan!`,
+      buildingRequirement: (label, size) => `Need a ${size}×${size} floor area cleared for ${label}.`,
+      loadSuccess: file => `Loaded layout from ${file}.`
+    },
+    signSection: {
+      legend: 'Note Board',
+      label: 'Note',
+      hint: 'Update existing notes by painting them again.',
+      placeholder: 'Remember to add plants'
+    },
+    preview: {
+      documentTitle: 'Interior Layout Preview',
+      title: 'Interior Layout Preview',
+      footer: 'Previewing building interior layout.',
+      background: 'radial-gradient(circle at top, rgba(200, 180, 255, 0.18), rgba(18, 12, 28, 0.95))'
+    }
+  };
+
+  mode.palette = [
+    { id: 'land', label: 'Floor', icon: '🧱', description: 'Lay down sturdy flooring.', category: 'base', base: 'land' },
+    { id: 'sea', label: 'Empty Space', icon: '⬛', description: 'Clear back to empty space.', category: 'base', base: 'sea' },
+    { id: 'carpet', label: 'Carpet', icon: '🟥', description: 'Add a soft carpet area.', category: 'overlay', overlay: 'carpet', requiresBase: 'land' },
+    { id: 'tile-inlay', label: 'Tile Inlay', icon: '🎨', description: 'Decorative tile pattern.', category: 'overlay', overlay: 'tile-inlay', requiresBase: 'land' },
+    { id: 'counter', label: 'Counter', icon: '🪑', description: 'Place interior counters or desks.', category: 'overlay', overlay: 'counter', requiresBase: 'land' },
+    { id: 'kennel', label: 'Kennel', icon: '🐶', description: 'Set a kennel space for pups.', category: 'overlay', overlay: 'kennel', requiresBase: 'land' },
+    { id: 'sign', label: 'Note', icon: '📝', description: 'Add designer notes for the room.', category: 'sign', requiresBase: 'land' }
+  ];
+
+  mode.toolsById = new Map(mode.palette.map(tool => [tool.id, tool]));
+
+  mode.normalizeSignText = text => normalizeText(text, mode.signMaxLength);
+
+  mode.getOverlaySymbol = tile => {
+    if (tile.overlay === mode.signToolId) {
+      return tile.signText || overlayEmoji[mode.signToolId] || '';
+    }
+    return overlayEmoji[tile.overlay] || '';
+  };
+
+  mode.describeOverlay = tile => {
+    if (tile.overlay === 'none') return '';
+    if (tile.overlay === mode.signToolId) {
+      return tile.signText ? `note “${tile.signText}”` : 'note';
+    }
+    return overlayLabels[tile.overlay] || tile.overlay.replace(/-/g, ' ');
+  };
+
+  mode.buildTileLayers = ({ tile }) => {
+    const overlayLayers = [];
+
+    if (mode.buildingTints[tile.overlay]) {
+      overlayLayers.push(tintLayer(mode.buildingTints[tile.overlay]));
+    } else if (tile.overlay === mode.signToolId) {
+      overlayLayers.push(tintLayer(mode.buildingTints[mode.signToolId]));
+    }
+
+    const baseLayer =
+      tile.base === 'sea'
+        ? tintLayer('rgba(20, 24, 32, 0.85)')
+        : tintLayer('rgba(120, 98, 82, 0.9)');
+
+    return overlayLayers.filter(Boolean).concat([baseLayer]);
+  };
+
+  mode.sanitizeTile = tile => {
+    const safeBase = mode.baseTypes.has(tile?.base) ? tile.base : mode.defaultTile().base;
+    let safeOverlay = mode.overlayTypes.has(tile?.overlay) ? tile.overlay : 'none';
+    let safeSign = '';
+
+    if (safeOverlay !== 'none' && safeBase !== mode.requiredBase) {
+      safeOverlay = 'none';
+    }
+
+    if (safeOverlay === mode.signToolId) {
+      safeSign = mode.normalizeSignText(tile?.signText);
+    }
+
+    return {
+      base: safeOverlay === 'none' ? safeBase : mode.requiredBase,
+      overlay: safeOverlay,
+      signText: safeSign
+    };
+  };
+
+  return mode;
+}
+
+export const DESIGN_MODES = Object.freeze({
+  town: createTownMode(),
+  interior: createInteriorMode()
+});
+
+export { TILE_SIZE, BRUSH_OPTIONS, DEFAULT_GRID_SIZE, GRID_LIMITS, tintLayer };

--- a/js/leveldesigner/preview-runtime.js
+++ b/js/leveldesigner/preview-runtime.js
@@ -1,0 +1,54 @@
+import { DESIGN_MODES, TILE_SIZE } from './modes.js';
+import { updateTileAppearance } from './rendering.js';
+
+const data = window.__LEVEL_DATA__ || {};
+const mode = DESIGN_MODES[data.modeId] || Object.values(DESIGN_MODES)[0];
+const layout = data.layout || { size: 0, tiles: [] };
+
+const map = document.getElementById('map');
+const titleElement = document.getElementById('previewTitle');
+const footerElement = document.getElementById('previewFooter');
+
+if (data.preview?.title) {
+  titleElement.textContent = data.preview.title;
+} else if (mode?.preview?.title) {
+  titleElement.textContent = mode.preview.title;
+}
+
+if (data.preview?.footer) {
+  footerElement.textContent = data.preview.footer;
+} else if (mode?.preview?.footer) {
+  footerElement.textContent = mode.preview.footer;
+}
+
+if (data.preview?.documentTitle) {
+  document.title = data.preview.documentTitle;
+} else if (mode?.preview?.documentTitle) {
+  document.title = mode.preview.documentTitle;
+}
+
+if (mode?.preview?.background) {
+  document.body.style.background = mode.preview.background;
+}
+
+if (!map || !layout.size || !Array.isArray(layout.tiles)) {
+  return;
+}
+
+map.style.setProperty('--tile-size', `${TILE_SIZE}px`);
+map.style.gridTemplateColumns = `repeat(${layout.size}, ${TILE_SIZE}px)`;
+map.style.gridTemplateRows = `repeat(${layout.size}, ${TILE_SIZE}px)`;
+
+const state = layout.tiles.map(row => row.map(tile => ({ ...tile })));
+
+for (let y = 0; y < layout.size; y++) {
+  for (let x = 0; x < layout.size; x++) {
+    const tile = state[y][x];
+    const cell = document.createElement('div');
+    cell.className = 'cell';
+    cell.dataset.x = x;
+    cell.dataset.y = y;
+    map.appendChild(cell);
+    updateTileAppearance({ element: cell, tile, x, y, mode, state, gridSize: layout.size });
+  }
+}

--- a/js/leveldesigner/rendering.js
+++ b/js/leveldesigner/rendering.js
@@ -1,0 +1,43 @@
+function applyLayers(element, layers) {
+  if (!layers.length) {
+    element.style.backgroundImage = 'none';
+    element.style.backgroundSize = '';
+    element.style.backgroundPosition = '';
+    element.style.backgroundRepeat = '';
+    return;
+  }
+
+  element.style.backgroundImage = layers.map(layer => layer.image).join(', ');
+  element.style.backgroundSize = layers.map(layer => layer.size).join(', ');
+  element.style.backgroundPosition = layers.map(layer => layer.position).join(', ');
+  element.style.backgroundRepeat = layers.map(() => 'no-repeat').join(', ');
+}
+
+function updateTileAppearance({ element, tile, x, y, mode, state, gridSize }) {
+  element.dataset.base = tile.base;
+  element.dataset.overlay = tile.overlay;
+
+  if (tile.signText) {
+    element.dataset.signText = tile.signText;
+  } else {
+    delete element.dataset.signText;
+  }
+
+  const layers = mode.buildTileLayers({ state, gridSize, tile, x, y });
+  applyLayers(element, layers.filter(Boolean));
+
+  const symbol = mode.getOverlaySymbol(tile);
+  if (symbol) {
+    element.dataset.overlaySymbol = symbol;
+  } else {
+    delete element.dataset.overlaySymbol;
+  }
+
+  const baseLabel = mode.baseLabels[tile.base] || tile.base;
+  const overlayDescription = tile.overlay === 'none' ? '' : mode.describeOverlay(tile);
+  const ariaLabel = overlayDescription ? `${baseLabel} tile with ${overlayDescription}` : `${baseLabel} tile`;
+  element.setAttribute('aria-label', ariaLabel);
+  element.title = tile.overlay === mode.signToolId && tile.signText ? tile.signText : '';
+}
+
+export { applyLayers, updateTileAppearance };

--- a/js/leveldesigner/state.js
+++ b/js/leveldesigner/state.js
@@ -1,0 +1,17 @@
+function createGrid(size, createTile) {
+  const grid = [];
+  for (let y = 0; y < size; y++) {
+    const row = [];
+    for (let x = 0; x < size; x++) {
+      row.push(createTile());
+    }
+    grid.push(row);
+  }
+  return grid;
+}
+
+function cloneGrid(grid) {
+  return grid.map(row => row.map(tile => ({ ...tile })));
+}
+
+export { createGrid, cloneGrid };

--- a/js/leveldesigner/tools.js
+++ b/js/leveldesigner/tools.js
@@ -1,0 +1,144 @@
+function getBuildingArea(mode, gridSize, x, y) {
+  const size = mode.buildingSize;
+  const half = Math.floor(size / 2);
+  const startX = Math.max(0, Math.min(x - half, gridSize - size));
+  const startY = Math.max(0, Math.min(y - half, gridSize - size));
+  return { startX, startY, size };
+}
+
+function canPlaceBuilding({ mode, state, gridSize, x, y, overlay }) {
+  if (!mode.buildingTools.has(overlay)) return false;
+  const { startX, startY, size } = getBuildingArea(mode, gridSize, x, y);
+  for (let by = 0; by < size; by++) {
+    for (let bx = 0; bx < size; bx++) {
+      const nx = startX + bx;
+      const ny = startY + by;
+      const tile = state[ny][nx];
+      if (tile.base !== mode.requiredBase) return false;
+      if (tile.overlay !== 'none' && tile.overlay !== overlay) return false;
+    }
+  }
+  return true;
+}
+
+function applyBuilding({ mode, state, gridSize, x, y, overlay, onTileUpdated }) {
+  const { startX, startY, size } = getBuildingArea(mode, gridSize, x, y);
+  for (let by = 0; by < size; by++) {
+    for (let bx = 0; bx < size; bx++) {
+      const nx = startX + bx;
+      const ny = startY + by;
+      const tile = state[ny][nx];
+      tile.base = mode.requiredBase;
+      tile.overlay = overlay;
+      tile.signText = '';
+      onTileUpdated(nx, ny);
+    }
+  }
+  return true;
+}
+
+function applyTool({ mode, state, gridSize, x, y, toolId, signText, onTileUpdated, updateStatus }) {
+  const tool = mode.toolsById.get(toolId);
+  if (!tool) return false;
+
+  const tile = state[y][x];
+  switch (tool.category) {
+    case 'base': {
+      const changed = tile.base !== tool.base || tile.overlay !== 'none' || tile.signText !== '';
+      tile.base = tool.base;
+      tile.overlay = 'none';
+      tile.signText = '';
+      if (changed) {
+        onTileUpdated(x, y);
+      }
+      return changed;
+    }
+    case 'overlay': {
+      if (tool.requiresBase && tile.base !== tool.requiresBase) {
+        return false;
+      }
+      if (tile.overlay === tool.overlay) {
+        return false;
+      }
+      tile.overlay = tool.overlay;
+      tile.signText = '';
+      onTileUpdated(x, y);
+      return true;
+    }
+    case 'sign': {
+      if (tool.requiresBase && tile.base !== tool.requiresBase) {
+        return false;
+      }
+      const cleaned = mode.normalizeSignText(signText);
+      if (tile.overlay === mode.signToolId && tile.signText === cleaned) {
+        return false;
+      }
+      tile.overlay = mode.signToolId;
+      tile.signText = cleaned;
+      onTileUpdated(x, y);
+      return true;
+    }
+    case 'building': {
+      if (!mode.buildingTools.has(tool.overlay)) {
+        return false;
+      }
+      if (!canPlaceBuilding({ mode, state, gridSize, x, y, overlay: tool.overlay })) {
+        if (typeof updateStatus === 'function') {
+          const size = mode.buildingSize;
+          updateStatus(mode.messages.buildingRequirement(tool.label, size));
+        }
+        return false;
+      }
+      return applyBuilding({ mode, state, gridSize, x, y, overlay: tool.overlay, onTileUpdated });
+    }
+    default:
+      return false;
+  }
+}
+
+function applyBrush({
+  mode,
+  state,
+  gridSize,
+  x,
+  y,
+  toolId,
+  brushSize,
+  onTileUpdated,
+  updateStatus,
+  signText
+}) {
+  const span = mode.brushTools.has(toolId) ? Math.min(brushSize, gridSize) : 1;
+  const startX = Math.max(0, Math.min(x, gridSize - span));
+  const startY = Math.max(0, Math.min(y, gridSize - span));
+  let needsBase = false;
+
+  for (let by = 0; by < span; by++) {
+    for (let bx = 0; bx < span; bx++) {
+      const nx = startX + bx;
+      const ny = startY + by;
+      const target = state[ny][nx];
+      if (mode.landOnlyTools.has(toolId) && target.base !== mode.requiredBase) {
+        needsBase = true;
+        continue;
+      }
+      applyTool({
+        mode,
+        state,
+        gridSize,
+        x: nx,
+        y: ny,
+        toolId,
+        signText,
+        onTileUpdated,
+        updateStatus
+      });
+    }
+  }
+
+  if (needsBase && typeof updateStatus === 'function') {
+    updateStatus(mode.messages.needsBase);
+  }
+}
+
+export { applyBrush, applyTool };

--- a/leveldesign.html
+++ b/leveldesign.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Town Level Designer</title>
+  <title>Level Designer</title>
   <style>
     :root {
       color-scheme: dark;
@@ -32,11 +32,37 @@
       gap: 1rem;
     }
 
+    header > div {
+      display: grid;
+      gap: 0.35rem;
+    }
+
     h1 {
       margin: 0;
       font-size: clamp(1.6rem, 3vw, 2.3rem);
       letter-spacing: 0.08em;
       text-transform: uppercase;
+    }
+
+    #designerTagline {
+      font-size: 0.95rem;
+      color: rgba(207, 227, 255, 0.8);
+    }
+
+    .mode-switch {
+      display: grid;
+      gap: 0.35rem;
+      font-size: 0.95rem;
+      color: rgba(207, 227, 255, 0.8);
+    }
+
+    .mode-switch select {
+      padding: 0.4rem 0.6rem;
+      border-radius: 0.6rem;
+      border: 1px solid rgba(158, 203, 255, 0.4);
+      background: rgba(24, 42, 64, 0.65);
+      color: inherit;
+      font-size: 0.95rem;
     }
 
     .controls {
@@ -202,8 +228,8 @@
       filter: brightness(1.05);
       transform: scale(1.02);
     }
-    
-.tile::after {
+
+    .tile::after {
       content: attr(data-overlay-symbol);
       position: absolute;
       inset: 0;
@@ -213,67 +239,6 @@
       color: #fff9c4;
       text-shadow: 0 1px 2px rgba(0, 0, 0, 0.6);
       pointer-events: none;
-    }
-
-    .tile[data-overlay="sign"]::after {
-      font-size: calc(var(--tile-size) * 0.4);
-      font-weight: 600;
-      letter-spacing: 0.04em;
-      text-transform: uppercase;
-      color: #ffe8b0;
-    }
-
-
-    .tile[data-base="sea"] {
-      background: linear-gradient(135deg, #0f3057, #0b1f36);
-      color: #9ecbff;
-    }
-
-    .tile[data-base="land"] {
-      background: linear-gradient(135deg, #3a5f2b, #1f3317);
-      color: #f1ffe2;
-    }
-
-    .tile[data-overlay="path"] {
-      background: linear-gradient(135deg, #5b4d3b, #3c3226);
-      color: #fbe4c1;
-    }
-
-    .tile[data-overlay="grass"] {
-      background: linear-gradient(135deg, #4d8f3a, #2f6124);
-    }
-
-    .tile[data-overlay="house"] {
-      background: linear-gradient(135deg, #5c1f2f, #35101b);
-    }
-
-    .tile[data-overlay="vets"] {
-      background: linear-gradient(135deg, #234c5c, #15313d);
-    }
-
-    .tile[data-overlay="dog-training"] {
-      background: linear-gradient(135deg, #50396b, #2f2042);
-    }
-
-    .tile[data-overlay="dog-groomers"] {
-      background: linear-gradient(135deg, #7f3b63, #4a1f38);
-    }
-
-    .tile[data-overlay="dog-show"] {
-      background: linear-gradient(135deg, #73571d, #43340f);
-    }
-
-    .tile[data-overlay="pet-shop"] {
-      background: linear-gradient(135deg, #2c5935, #1a3620);
-    }
-
-    .tile[data-overlay="sign"] {
-      background: linear-gradient(135deg, #8a5a24, #503014);
-      font-size: calc(var(--tile-size) * 0.32);
-      padding: 0 0.2rem;
-      text-overflow: ellipsis;
-      overflow: hidden;
-      white-space: nowrap;
     }
 
     #status {
@@ -304,7 +269,8 @@
     .primary:hover {
       transform: translateY(-1px) scale(1.01);
     }
-.secondary {
+
+    .secondary {
       border: 1px solid rgba(158, 203, 255, 0.4);
       background: rgba(24, 42, 64, 0.7);
       padding: 0.75rem 1.2rem;
@@ -346,10 +312,14 @@
 </head>
 <body>
   <header>
-    <h1>Town Level Designer</h1>
     <div>
-      <span>Left click to paint • Right click to sea</span>
+      <h1 id="designerTitle">Town Level Designer</h1>
+      <div id="designerTagline">Left click to paint • Right click to sea</div>
     </div>
+    <label class="mode-switch">
+      <span>Design Mode</span>
+      <select id="modeSelect" aria-label="Select design mode"></select>
+    </label>
   </header>
 
   <section class="controls" aria-label="Designer Controls">
@@ -361,7 +331,7 @@
     <fieldset>
       <legend>Brush Size</legend>
       <div class="brush-options" id="brushOptions" role="group" aria-label="Brush size options"></div>
-      <p class="hint">Brush applies to Land and Grass tools (square size per side).</p>
+      <p class="hint">Brush applies to selected terrain tools (square size per side).</p>
     </fieldset>
 
     <fieldset class="map-settings">
@@ -371,11 +341,11 @@
     </fieldset>
 
     <fieldset>
-      <legend>Sign Writer</legend>
+      <legend id="signLegend">Sign Writer</legend>
       <div class="sign-input">
-        <label for="signText">Message</label>
+        <label id="signLabel" for="signText">Message</label>
         <input type="text" id="signText" maxlength="32" placeholder="Welcome adventurers" />
-        <p class="hint">Update existing signs by painting them again.</p>
+        <p class="hint" id="signHint">Update existing signs by painting them again.</p>
       </div>
     </fieldset>
 
@@ -399,865 +369,6 @@
     <button class="tile" type="button"></button>
   </template>
 
-  <script>
-    const TILE_SIZE = 32;
-    const BRUSH_OPTIONS = [1, 2, 4, 8];
-    const BRUSH_TOOLS = new Set(['land', 'grass', 'short-grass', 'long-grass']);
-
-    const palette = [
-      { id: 'land', label: 'Land', icon: '🏝️', description: 'Claim land from the surrounding sea.' },
-      { id: 'sea', label: 'Sea', icon: '🌊', description: 'Return a tile to open water.' },
-      { id: 'grass', label: 'Grass', icon: '🌱', description: 'Add standard grass using the shared tileset.' },
-      { id: 'short-grass', label: 'Short Grass', icon: '🌾', description: 'Trimmed grass variant for tidy areas.' },
-      { id: 'long-grass', label: 'Long Grass', icon: '🌿', description: 'Tall grass using the long grass sheet.' },
-      { id: 'path', label: 'Path', icon: '🪨', description: 'Lay walking paths for players.' },
-      { id: 'house', label: 'House', icon: '🏠', description: 'Place village houses on land.' },
-      { id: 'vets', label: 'Vets', icon: '🐾', description: 'Mark veterinary services for pets.' },
-      { id: 'dog-training', label: 'Dog Training', icon: '🎯', description: 'Plan dedicated dog training areas.' },
-      { id: 'dog-groomers', label: 'Dog Groomers', icon: '✂️', description: 'Set up grooming parlours for pups.' },
-      { id: 'dog-show', label: 'Dog Show', icon: '🏆', description: 'Designate the show arena.' },
-      { id: 'pet-shop', label: 'Pet Shop', icon: '🛍️', description: 'Place pet supply stores.' },
-      { id: 'sign', label: 'Sign', icon: '🪧', description: 'Add signage for directions or lore.' }
-    ];
-
-    const overlayEmoji = {
-      none: '',
-      grass: '',
-      'short-grass': '',
-      'long-grass': '',
-      path: '',
-      house: '🏠',
-      vets: '🐾',
-      'dog-training': '🎯',
-      'dog-groomers': '✂️',
-      'dog-show': '🏆',
-      'pet-shop': '🛍️',
-      sign: '🪧'
-    };
-
-    const landOnlyTools = new Set([
-      'grass',
-      'short-grass',
-      'long-grass',
-      'path',
-      'house',
-      'vets',
-      'dog-training',
-      'dog-groomers',
-      'dog-show',
-      'pet-shop',
-      'sign'
-    ]);
-    const buildingTools = new Set(['house', 'vets', 'dog-training', 'dog-groomers', 'dog-show', 'pet-shop']);
-
-    let currentTool = 'land';
-    let gridSize = 16;
-    let mouseDown = false;
-    let brushDimension = 1;
-    let currentSignText = '';
-
-    const gridElement = document.getElementById('grid');
-    const statusElement = document.getElementById('status');
-
-    const tileTemplate = document.getElementById('tileTemplate');
-    const brushContainer = document.getElementById('brushOptions');
-    const signInput = document.getElementById('signText');
-
-    const baseTypes = new Set(['sea', 'land']);
-    const overlayTypes = new Set([
-      'none',
-      'grass',
-      'path',
-      'short-grass',
-      'long-grass',
-      'house',
-      'vets',
-      'dog-training',
-      'dog-groomers',
-      'dog-show',
-      'pet-shop',
-      'sign'
-    ]);
-
-    const state = [];
-    const tileElements = [];
-
-    const SPRITES = {
-      land: { src: 'assets/dirt.png', columns: 8, rows: 8 },
-      path: { src: 'assets/dirt.png', columns: 8, rows: 8 },
-      grass: { src: 'assets/grass.png', columns: 8, rows: 8 },
-      longGrass: { src: 'assets/long-grass.png', columns: 8, rows: 8 },
-      water: { src: 'assets/water.png', columns: 8, rows: 8 }
-    };
-
-    const BUILDING_SIZE = 5;
-
-    const BUILDING_TINTS = {
-      house: 'rgba(199, 98, 120, 0.72)',
-      vets: 'rgba(70, 140, 180, 0.72)',
-      'dog-training': 'rgba(138, 109, 200, 0.72)',
-      'dog-groomers': 'rgba(200, 90, 150, 0.72)',
-      'dog-show': 'rgba(200, 170, 90, 0.72)',
-      'pet-shop': 'rgba(90, 170, 120, 0.72)'
-    };
-
-    const NINE_SLICE_COORDS = {
-      single: { col: 0, row: 1 },
-      topLeft: { col: 2, row: 0 },
-      top: { col: 2, row: 1 },
-      topRight: { col: 2, row: 2 },
-      left: { col: 3, row: 0 },
-      center: { col: 3, row: 1 },
-      right: { col: 3, row: 2 },
-      bottomLeft: { col: 4, row: 0 },
-      bottom: { col: 4, row: 2 },
-      bottomRight: { col: 4, row: 3 }
-    };
-
-    function isInside(x, y) {
-      return y >= 0 && y < gridSize && x >= 0 && x < gridSize;
-    }
-
-    function computeNineSliceKey(x, y, matchFn) {
-      const up = matchFn(x, y - 1);
-      const down = matchFn(x, y + 1);
-      const left = matchFn(x - 1, y);
-      const right = matchFn(x + 1, y);
-
-      if (!up && !down && !left && !right) return 'single';
-      if (!up && !left) return 'topLeft';
-      if (!up && !right) return 'topRight';
-      if (!down && !left) return 'bottomLeft';
-      if (!down && !right) return 'bottomRight';
-      if (!up) return 'top';
-      if (!down) return 'bottom';
-      if (!left) return 'left';
-      if (!right) return 'right';
-      return 'center';
-    }
-
-    function spriteLayer(key, frame) {
-      const sheet = SPRITES[key];
-      if (!sheet || !frame) return null;
-      const sizeX = sheet.columns * TILE_SIZE;
-      const sizeY = sheet.rows * TILE_SIZE;
-      return {
-        image: `url(${sheet.src})`,
-        size: `${sizeX}px ${sizeY}px`,
-        position: `${-frame.col * TILE_SIZE}px ${-frame.row * TILE_SIZE}px`
-      };
-    }
-
-    function tintLayer(color) {
-      return { image: `linear-gradient(${color}, ${color})`, size: '100% 100%', position: '0 0' };
-    }
-
-    function landMatch(x, y) {
-      return isInside(x, y) && state[y][x].base === 'land';
-    }
-
-    function overlayMatch(x, y, overlay) {
-      return isInside(x, y) && state[y][x].overlay === overlay;
-    }
-
-    function getLandFrame(x, y) {
-      const key = computeNineSliceKey(x, y, landMatch);
-      return NINE_SLICE_COORDS[key] || NINE_SLICE_COORDS.center;
-    }
-
-    function getOverlayFrame(x, y, overlay) {
-      const key = computeNineSliceKey(x, y, (nx, ny) => overlayMatch(nx, ny, overlay));
-      return NINE_SLICE_COORDS[key] || NINE_SLICE_COORDS.center;
-    }
-
-    function getShortGrassFrame(x, y) {
-      const variants = [
-        { col: 7, row: 0 },
-        { col: 7, row: 1 },
-        { col: 7, row: 2 },
-        { col: 7, row: 3 }
-      ];
-      const index = Math.abs((x * 131 + y * 17) % variants.length);
-      return variants[index];
-    }
-
-    function buildTileLayers(x, y, tile) {
-      const overlayLayers = [];
-
-      switch (tile.overlay) {
-        case 'grass':
-          overlayLayers.push(spriteLayer('grass', getOverlayFrame(x, y, 'grass')));
-          break;
-        case 'long-grass':
-          overlayLayers.push(spriteLayer('longGrass', getOverlayFrame(x, y, 'long-grass')));
-          break;
-        case 'short-grass':
-          overlayLayers.push(spriteLayer('grass', getShortGrassFrame(x, y)));
-          break;
-        case 'path':
-          overlayLayers.push(spriteLayer('path', getOverlayFrame(x, y, 'path')));
-          break;
-        case 'sign':
-          overlayLayers.push(tintLayer('rgba(150, 98, 45, 0.75)'));
-          break;
-        default:
-          if (BUILDING_TINTS[tile.overlay]) {
-            overlayLayers.push(tintLayer(BUILDING_TINTS[tile.overlay]));
-          }
-      }
-
-      const baseLayer =
-        tile.base === 'sea'
-          ? spriteLayer('water', { col: 0, row: 0 })
-          : spriteLayer('land', getLandFrame(x, y));
-
-      return overlayLayers.filter(Boolean).concat(baseLayer ? [baseLayer] : []);
-    }
-
-    function applyLayers(tileElement, layers) {
-      if (!layers.length) {
-        tileElement.style.backgroundImage = 'none';
-        tileElement.style.backgroundSize = '';
-        tileElement.style.backgroundPosition = '';
-        tileElement.style.backgroundRepeat = '';
-        return;
-      }
-
-      tileElement.style.backgroundImage = layers.map(layer => layer.image).join(', ');
-      tileElement.style.backgroundSize = layers.map(layer => layer.size).join(', ');
-      tileElement.style.backgroundPosition = layers.map(layer => layer.position).join(', ');
-      tileElement.style.backgroundRepeat = layers.map(() => 'no-repeat').join(', ');
-    }
-
-    function getBuildingArea(x, y) {
-      const half = Math.floor(BUILDING_SIZE / 2);
-      const startX = Math.max(0, Math.min(x - half, gridSize - BUILDING_SIZE));
-      const startY = Math.max(0, Math.min(y - half, gridSize - BUILDING_SIZE));
-      return { startX, startY };
-    }
-
-    function canPlaceBuilding(x, y, overlay) {
-      const { startX, startY } = getBuildingArea(x, y);
-      for (let by = 0; by < BUILDING_SIZE; by++) {
-        for (let bx = 0; bx < BUILDING_SIZE; bx++) {
-          const nx = startX + bx;
-          const ny = startY + by;
-          const tile = state[ny][nx];
-          if (tile.base !== 'land') return false;
-          if (tile.overlay !== 'none' && tile.overlay !== overlay) return false;
-        }
-      }
-      return true;
-    }
-
-    function applyBuilding(x, y, overlay) {
-      const { startX, startY } = getBuildingArea(x, y);
-      for (let by = 0; by < BUILDING_SIZE; by++) {
-        for (let bx = 0; bx < BUILDING_SIZE; bx++) {
-          const nx = startX + bx;
-          const ny = startY + by;
-          const tile = state[ny][nx];
-          tile.base = 'land';
-          tile.overlay = overlay;
-          tile.signText = '';
-          const element = tileElements[ny]?.[nx];
-          if (element) {
-            updateTileAppearance(element, tile);
-          }
-        }
-      }
-      return true;
-    }
-
-    signInput.addEventListener('input', event => {
-      currentSignText = event.target.value.trim();
-    });
-
-    function initPalette() {
-      const toolList = document.getElementById('toolList');
-      palette.forEach(tool => {
-        const button = document.createElement('button');
-        button.type = 'button';
-        button.className = 'tool';
-        button.dataset.tool = tool.id;
-        button.innerHTML = `<span class="tool-icon">${tool.icon}</span> ${tool.label}`;
-        button.title = tool.description;
-        if (tool.id === currentTool) button.classList.add('active');
-        button.addEventListener('click', () => {
-          currentTool = tool.id;
-          toolList.querySelectorAll('.tool').forEach(btn => btn.classList.toggle('active', btn === button));
-          updateStatus(`Selected ${tool.label}. ${tool.description}`);
-        });
-        toolList.appendChild(button);
-      });
-    }
-
-    function initBrushOptions() {
-      BRUSH_OPTIONS.forEach(size => {
-        const button = document.createElement('button');
-        button.type = 'button';
-        button.className = 'brush';
-        button.dataset.size = size;
-        button.textContent = `${size}×${size}`;
-        if (size === brushDimension) button.classList.add('active');
-        button.addEventListener('click', () => {
-          brushDimension = size;
-          brushContainer.querySelectorAll('.brush').forEach(btn => btn.classList.toggle('active', btn === button));
-          updateStatus(`Brush size set to ${size}×${size} tiles for Land and Grass.`);
-        });
-        brushContainer.appendChild(button);
-      });
-    }
-
-    function createState(size) {
-      state.length = 0;
-      for (let y = 0; y < size; y++) {
-        const row = [];
-        for (let x = 0; x < size; x++) {
-          row.push({ base: 'sea', overlay: 'none', signText: '' });
-        }
-        state.push(row);
-      }
-    }
-
-    function renderGrid() {
-      gridElement.innerHTML = '';
-      gridElement.style.setProperty('--tile-size', `${TILE_SIZE}px`);
-      gridElement.style.gridTemplateColumns = `repeat(${gridSize}, ${TILE_SIZE}px)`;
-      gridElement.style.gridTemplateRows = `repeat(${gridSize}, ${TILE_SIZE}px)`;
-      gridElement.style.width = `${gridSize * TILE_SIZE}px`;
-      gridElement.style.height = `${gridSize * TILE_SIZE}px`;
-      tileElements.length = 0;
-
-      for (let y = 0; y < gridSize; y++) {
-        tileElements[y] = [];
-        for (let x = 0; x < gridSize; x++) {
-          const tileState = state[y][x];
-          const tile = tileTemplate.content.firstElementChild.cloneNode(true);
-          tile.dataset.x = x;
-          tile.dataset.y = y;
-          updateTileAppearance(tile, tileState);
-          tile.addEventListener('pointerdown', handlePointerDown);
-          tile.addEventListener('pointerenter', handlePointerEnter);
-          tile.addEventListener('contextmenu', event => event.preventDefault());
-          tileElements[y][x] = tile;
-          gridElement.appendChild(tile);
-        }
-      }
-    }
-
-    function updateTileAppearance(tile, tileState) {
-      tile.dataset.base = tileState.base;
-      tile.dataset.overlay = tileState.overlay;
-      if (tileState.signText) {
-        tile.dataset.signText = tileState.signText;
-      } else {
-        delete tile.dataset.signText;
-      }
-
-      const x = Number(tile.dataset.x);
-      const y = Number(tile.dataset.y);
-      const layers = buildTileLayers(x, y, tileState);
-      applyLayers(tile, layers);
-
-      const symbol =
-        tileState.overlay === 'sign'
-          ? tileState.signText || overlayEmoji.sign
-          : overlayEmoji[tileState.overlay] || '';
-      if (symbol) {
-        tile.dataset.overlaySymbol = symbol;
-      } else {
-        delete tile.dataset.overlaySymbol;
-      }
-
-      const overlayLabel =
-        tileState.overlay === 'none'
-          ? ''
-          : tileState.overlay === 'sign'
-            ? tileState.signText
-              ? ` with sign “${tileState.signText}”`
-              : ' with sign'
-            : ` with ${tileState.overlay.replace(/-/g, ' ')}`;
-      tile.setAttribute('aria-label', `${tileState.base} tile${overlayLabel}`);
-      tile.title = tileState.overlay === 'sign' && tileState.signText ? tileState.signText : '';
-    }
-
-    function applyTool(x, y, tool = currentTool) {
-      const tile = state[y][x];
-      switch (tool) {
-        case 'sea': {
-          const changed = tile.base !== 'sea' || tile.overlay !== 'none' || tile.signText !== '';
-          tile.base = 'sea';
-          tile.overlay = 'none';
-          tile.signText = '';
-          return changed;
-        }
-        case 'land': {
-          const changed = tile.base !== 'land' || tile.overlay !== 'none' || tile.signText !== '';
-          tile.base = 'land';
-          tile.overlay = 'none';
-          tile.signText = '';
-          return changed;
-        }
-        case 'grass':
-        case 'short-grass':
-        case 'long-grass':
-        case 'path': {
-          if (tile.base !== 'land') return false;
-          if (tile.overlay === tool) return false;
-          tile.overlay = tool;
-          tile.signText = '';
-          return true;
-        }
-        case 'sign': {
-          if (tile.base !== 'land') return false;
-          const text = currentSignText;
-          if (tile.overlay === 'sign' && tile.signText === text) return false;
-          tile.overlay = 'sign';
-          tile.signText = text;
-          return true;
-        }
-        default: {
-          if (buildingTools.has(tool)) {
-            if (!canPlaceBuilding(x, y, tool)) {
-              updateStatus(`Need a ${BUILDING_SIZE}×${BUILDING_SIZE} land area cleared for ${tool.replace(/-/g, ' ')}.`);
-              return false;
-            }
-            return applyBuilding(x, y, tool);
-          }
-        }
-      }
-      return false;
-    }
-
-    function applyBrush(x, y, tool) {
-      const span = BRUSH_TOOLS.has(tool) ? Math.min(brushDimension, gridSize) : 1;
-      const startX = Math.max(0, Math.min(x, gridSize - span));
-      const startY = Math.max(0, Math.min(y, gridSize - span));
-      let needsLand = false;
-
-      for (let by = 0; by < span; by++) {
-        for (let bx = 0; bx < span; bx++) {
-          const nx = startX + bx;
-          const ny = startY + by;
-          const tileState = state[ny][nx];
-          if (landOnlyTools.has(tool) && tileState.base !== 'land') {
-            needsLand = true;
-            continue;
-          }
-          if (applyTool(nx, ny, tool)) {
-            const row = tileElements[ny];
-            if (row) {
-              const tile = row[nx];
-              if (tile) {
-                updateTileAppearance(tile, state[ny][nx]);
-              }
-            }
-          }
-        }
-      }
-
-      if (needsLand) {
-        updateStatus('Claim land before placing terrain, buildings, or signs.');
-      }
-    }
-
-    function handlePointerDown(event) {
-      event.preventDefault();
-      const tool = event.button === 2 ? 'sea' : currentTool;
-      const x = Number(event.currentTarget.dataset.x);
-      const y = Number(event.currentTarget.dataset.y);
-      mouseDown = true;
-      applyBrush(x, y, tool);
-      window.addEventListener('pointerup', handlePointerUp, { once: true });
-    }
-
-    function handlePointerEnter(event) {
-      if (!mouseDown) return;
-      const tool = event.buttons === 2 ? 'sea' : currentTool;
-      const x = Number(event.currentTarget.dataset.x);
-      const y = Number(event.currentTarget.dataset.y);
-      applyBrush(x, y, tool);
-    }
-
-    function handlePointerUp() {
-      mouseDown = false;
-    }
-
-    function updateStatus(message) {
-      statusElement.textContent = message;
-    }
-
-    function resizeGrid() {
-      const requested = Number(document.getElementById('gridSize').value);
-      if (!Number.isInteger(requested) || requested < 6 || requested > 50) {
-        updateStatus('Grid size must be between 6 and 50.');
-        return;
-      }
-      gridSize = requested;
-      createState(gridSize);
-      renderGrid();
-      updateStatus(`Grid resized to ${gridSize} × ${gridSize}. Start shaping your land!`);
-    }
-
-    function exportJson() {
-      const layout = {
-        size: gridSize,
-        tiles: state
-      };
-      const blob = new Blob([JSON.stringify(layout, null, 2)], { type: 'application/json' });
-      const link = document.createElement('a');
-      link.href = URL.createObjectURL(blob);
-      link.download = 'town-layout.json';
-      link.click();
-      URL.revokeObjectURL(link.href);
-    }
-
-    function loadJsonFromFile(file) {
-      const reader = new FileReader();
-      reader.addEventListener('load', () => {
-        try {
-          const parsed = JSON.parse(reader.result);
-          applyLayout(parsed);
-          updateStatus(`Loaded layout from ${file.name}.`);
-        } catch (error) {
-          console.error('Failed to load layout', error);
-          const message = error instanceof Error ? error.message : 'Invalid JSON file.';
-          updateStatus(`Unable to load layout: ${message}`);
-        }
-      });
-      reader.readAsText(file);
-    }
-
-    function applyLayout(layout) {
-      if (!layout || typeof layout !== 'object') {
-        throw new Error('Layout must be an object.');
-      }
-      const size = Number(layout.size);
-      if (!Number.isInteger(size) || size < 6 || size > 50) {
-        throw new Error('Layout size out of bounds.');
-      }
-      const tiles = layout.tiles;
-      if (!Array.isArray(tiles) || tiles.length !== size) {
-        throw new Error('Tiles array does not match layout size.');
-      }
-
-      gridSize = size;
-      createState(gridSize);
-
-      for (let y = 0; y < gridSize; y++) {
-        const row = tiles[y];
-        if (!Array.isArray(row) || row.length !== gridSize) {
-          throw new Error('Tile rows must match layout size.');
-        }
-        for (let x = 0; x < gridSize; x++) {
-          state[y][x] = sanitizeTile(row[x]);
-        }
-      }
-
-      document.getElementById('gridSize').value = gridSize;
-      renderGrid();
-      mouseDown = false;
-    }
-
-    function sanitizeTile(tile) {
-      const safeBase = baseTypes.has(tile?.base) ? tile.base : 'sea';
-      let safeOverlay = overlayTypes.has(tile?.overlay) ? tile.overlay : 'none';
-      let safeSign = '';
-
-      if (safeOverlay !== 'none' && safeBase !== 'land') {
-        safeOverlay = 'none';
-      }
-
-      if (safeOverlay === 'sign') {
-        safeSign = typeof tile?.signText === 'string' ? tile.signText.slice(0, 32).trim() : '';
-      }
-
-      return {
-        base: safeOverlay === 'none' ? safeBase : 'land',
-        overlay: safeOverlay,
-        signText: safeSign
-      };
-    }
-
-    function openLevelPage() {
-      const levelHtml = generateLevelHtml();
-      const levelWindow = window.open('', '_blank');
-      if (!levelWindow) {
-        updateStatus('Pop-up blocked. Allow pop-ups to open the level page.');
-        return;
-      }
-      levelWindow.document.write(levelHtml);
-      levelWindow.document.close();
-    }
-
-    function generateLevelHtml() {
-      const snapshot = state.map(row =>
-        row.map(tile => ({ base: tile.base, overlay: tile.overlay, signText: tile.signText }))
-      );
-      const layoutJson = JSON.stringify({ size: gridSize, tiles: snapshot });
-      const overlaySymbols = JSON.stringify(overlayEmoji);
-      const buildingTints = JSON.stringify(BUILDING_TINTS);
-
-      return `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Town Level Preview</title>
-  <style>
-    :root { color-scheme: dark; }
-    body {
-      margin: 0;
-      min-height: 100vh;
-      display: grid;
-      place-items: center;
-      background: radial-gradient(circle at top, rgba(120, 180, 255, 0.18), rgba(9, 14, 24, 0.95));
-      font-family: "Segoe UI", system-ui, sans-serif;
-      color: #eef5ff;
-    }
-    main {
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      gap: 1rem;
-    }
-    h1 { margin: 0; letter-spacing: 0.08em; text-transform: uppercase; }
-    .map {
-      --tile-size: 32px;
-      display: grid;
-      gap: 0;
-      background: #041422;
-      padding: 0.75rem;
-      border-radius: 1.2rem;
-      box-shadow: 0 1.5rem 3.5rem rgba(0, 0, 0, 0.4);
-    }
-    .cell {
-      width: var(--tile-size);
-      height: var(--tile-size);
-      position: relative;
-      background-repeat: no-repeat;
-      background-origin: border-box;
-      display: grid;
-      place-items: center;
-      font-size: calc(var(--tile-size) * 0.5);
-    }
-    .cell::after {
-      content: attr(data-overlay-symbol);
-      position: absolute;
-      inset: 0;
-      display: grid;
-      place-items: center;
-      font-size: calc(var(--tile-size) * 0.5);
-      color: #fff9c4;
-      text-shadow: 0 1px 2px rgba(0, 0, 0, 0.6);
-      pointer-events: none;
-    }
-    .cell[data-overlay="sign"]::after {
-      font-size: calc(var(--tile-size) * 0.4);
-      font-weight: 600;
-      letter-spacing: 0.04em;
-      text-transform: uppercase;
-      color: #ffe8b0;
-    }
-    footer { font-size: 0.9rem; color: rgba(238, 245, 255, 0.7); }
-  </style>
-</head>
-<body>
-  <main>
-    <h1>Town Level Preview</h1>
-    <section id="map" class="map" role="grid" aria-label="Town layout"></section>
-    <footer>Everything beyond the island edge is open sea and currently inaccessible.</footer>
-  </main>
-  <script>
-    const TILE_SIZE = 32;
-    const SPRITES = {
-      land: { src: 'assets/dirt.png', columns: 8, rows: 8 },
-      path: { src: 'assets/dirt.png', columns: 8, rows: 8 },
-      grass: { src: 'assets/grass.png', columns: 8, rows: 8 },
-      longGrass: { src: 'assets/long-grass.png', columns: 8, rows: 8 },
-      water: { src: 'assets/water.png', columns: 8, rows: 8 }
-    };
-    const NINE_SLICE = {
-      single: { col: 0, row: 1 },
-      topLeft: { col: 2, row: 0 },
-      top: { col: 2, row: 1 },
-      topRight: { col: 2, row: 2 },
-      left: { col: 3, row: 0 },
-      center: { col: 3, row: 1 },
-      right: { col: 3, row: 2 },
-      bottomLeft: { col: 4, row: 0 },
-      bottom: { col: 4, row: 2 },
-      bottomRight: { col: 4, row: 3 }
-    };
-    const layout = ${layoutJson};
-    const OVERLAY_SYMBOLS = ${overlaySymbols};
-    const BUILDING_TINTS = ${buildingTints};
-
-    const map = document.getElementById('map');
-    map.style.setProperty('--tile-size', TILE_SIZE + 'px');
-    map.style.gridTemplateColumns = \`repeat(\${layout.size}, \${TILE_SIZE}px)\`;
-    map.style.gridTemplateRows = \`repeat(\${layout.size}, \${TILE_SIZE}px)\`;
-
-    function computeKey(x, y, matchFn) {
-      const up = matchFn(x, y - 1);
-      const down = matchFn(x, y + 1);
-      const left = matchFn(x - 1, y);
-      const right = matchFn(x + 1, y);
-      if (!up && !down && !left && !right) return 'single';
-      if (!up && !left) return 'topLeft';
-      if (!up && !right) return 'topRight';
-      if (!down && !left) return 'bottomLeft';
-      if (!down && !right) return 'bottomRight';
-      if (!up) return 'top';
-      if (!down) return 'bottom';
-      if (!left) return 'left';
-      if (!right) return 'right';
-      return 'center';
-    }
-
-    function spriteLayer(sheet, frame) {
-      if (!sheet || !frame) return null;
-      return {
-        image: \`url(\${sheet.src})\`,
-        size: \`\${sheet.columns * TILE_SIZE}px \${sheet.rows * TILE_SIZE}px\`,
-        position: \`\${-frame.col * TILE_SIZE}px \${-frame.row * TILE_SIZE}px\`
-      };
-    }
-
-    function tintLayer(color) {
-      return { image: \`linear-gradient(\${color}, \${color})\`, size: '100% 100%', position: '0 0' };
-    }
-
-    function inBounds(x, y) {
-      return y >= 0 && y < layout.size && x >= 0 && x < layout.size;
-    }
-
-    function landMatch(x, y) {
-      return inBounds(x, y) && layout.tiles[y][x].base === 'land';
-    }
-
-    function overlayMatch(x, y, overlay) {
-      return inBounds(x, y) && layout.tiles[y][x].overlay === overlay;
-    }
-
-    function landFrame(x, y) {
-      return NINE_SLICE[computeKey(x, y, landMatch)] || NINE_SLICE.center;
-    }
-
-    function overlayFrame(x, y, overlay) {
-      return NINE_SLICE[computeKey(x, y, (nx, ny) => overlayMatch(nx, ny, overlay))] || NINE_SLICE.center;
-    }
-
-    function shortGrassFrame(x, y) {
-      const variants = [
-        { col: 7, row: 0 },
-        { col: 7, row: 1 },
-        { col: 7, row: 2 },
-        { col: 7, row: 3 }
-      ];
-      const index = Math.abs((x * 131 + y * 17) % variants.length);
-      return variants[index];
-    }
-
-    function buildLayers(x, y, tile) {
-      const overlayLayers = [];
-      switch (tile.overlay) {
-        case 'grass':
-          overlayLayers.push(spriteLayer(SPRITES.grass, overlayFrame(x, y, 'grass')));
-          break;
-        case 'long-grass':
-          overlayLayers.push(spriteLayer(SPRITES.longGrass, overlayFrame(x, y, 'long-grass')));
-          break;
-        case 'short-grass':
-          overlayLayers.push(spriteLayer(SPRITES.grass, shortGrassFrame(x, y)));
-          break;
-        case 'path':
-          overlayLayers.push(spriteLayer(SPRITES.path, overlayFrame(x, y, 'path')));
-          break;
-        case 'sign':
-          overlayLayers.push(tintLayer('rgba(150, 98, 45, 0.75)'));
-          break;
-        default:
-          if (BUILDING_TINTS[tile.overlay]) {
-            overlayLayers.push(tintLayer(BUILDING_TINTS[tile.overlay]));
-          }
-      }
-      const baseLayer = tile.base === 'sea'
-        ? spriteLayer(SPRITES.water, { col: 0, row: 0 })
-        : spriteLayer(SPRITES.land, landFrame(x, y));
-      return overlayLayers.filter(Boolean).concat(baseLayer ? [baseLayer] : []);
-    }
-
-    function applyLayers(element, layers) {
-      if (!layers.length) {
-        element.style.backgroundImage = 'none';
-        element.style.backgroundSize = '';
-        element.style.backgroundPosition = '';
-        element.style.backgroundRepeat = '';
-        return;
-      }
-      element.style.backgroundImage = layers.map(l => l.image).join(', ');
-      element.style.backgroundSize = layers.map(l => l.size).join(', ');
-      element.style.backgroundPosition = layers.map(l => l.position).join(', ');
-      element.style.backgroundRepeat = layers.map(() => 'no-repeat').join(', ');
-    }
-
-    for (let y = 0; y < layout.size; y++) {
-      for (let x = 0; x < layout.size; x++) {
-        const tile = layout.tiles[y][x];
-        const cell = document.createElement('div');
-        cell.className = 'cell';
-        cell.dataset.x = x;
-        cell.dataset.y = y;
-        cell.dataset.base = tile.base;
-        cell.dataset.overlay = tile.overlay;
-        if (tile.overlay === 'sign' && tile.signText) {
-          cell.dataset.overlaySymbol = tile.signText;
-          cell.title = tile.signText;
-        } else if (OVERLAY_SYMBOLS[tile.overlay]) {
-          cell.dataset.overlaySymbol = OVERLAY_SYMBOLS[tile.overlay];
-        }
-        if (tile.overlay === 'sign' && tile.signText) {
-          cell.dataset.signText = tile.signText;
-        }
-        const layers = buildLayers(x, y, tile);
-        applyLayers(cell, layers);
-        map.appendChild(cell);
-      }
-    }
-  <\/script>
-</body>
-</html>`;
-    }
-
-    document.getElementById('resizeGrid').addEventListener('click', resizeGrid);
-    document.getElementById('downloadJson').addEventListener('click', exportJson);
-    document.getElementById('loadJson').addEventListener('click', () => {
-      document.getElementById('loadJsonInput').click();
-    });
-    document.getElementById('loadJsonInput').addEventListener('change', event => {
-      const [file] = event.target.files || [];
-      if (!file) return;
-      const isJsonType = file.type === 'application/json';
-      const isJsonName = file.name?.toLowerCase().endsWith('.json');
-      if (file.type && !isJsonType && !isJsonName) {
-        updateStatus('Please choose a JSON layout file.');
-        event.target.value = '';
-        return;
-      }
-      loadJsonFromFile(file);
-      event.target.value = '';
-    });
-    document.getElementById('openLevel').addEventListener('click', openLevelPage);
-    gridElement.addEventListener('pointerleave', () => (mouseDown = false));
-
-    initPalette();
-    initBrushOptions();
-    currentSignText = signInput.value.trim();
-    createState(gridSize);
-    renderGrid();
-    updateStatus('Select Land to shape your island, use Grass with larger brushes to fill areas, then add paths, specialist buildings, and custom signs. Right-click turns tiles back into sea.');
-  </script>
+  <script type="module" src="js/leveldesigner/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- extract the level designer logic into dedicated JavaScript modules for configuration, state, rendering, tools, and preview runtime
- refresh leveldesign.html to load the modular scripts, add a design mode selector, and update the controls for dynamic sign labels
- introduce an interior design mode alongside the existing town mode, including mode-specific palettes, messaging, and preview support

## Testing
- Manual: Opened leveldesign.html in a browser to verify both modes render and interact correctly

------
https://chatgpt.com/codex/tasks/task_e_68d9978891b0832f8cee3d4d0d9f937b