### PR TITLE
Add sprite picker interface and integrate shared sprite metadata

### DIFF
--- a/css/sprite-picker.css
+++ b/css/sprite-picker.css
@@ -1,0 +1,332 @@
+:root {
+  color-scheme: dark;
+  font-family: "Segoe UI", system-ui, -apple-system, sans-serif;
+  background: radial-gradient(circle at top, rgba(90, 140, 255, 0.18), rgba(10, 16, 26, 0.95));
+  color: #f4f7fb;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  padding: 2rem;
+  box-sizing: border-box;
+}
+
+main {
+  width: min(1200px, 100%);
+  display: grid;
+  grid-template-columns: 300px 1fr;
+  gap: 1.5rem;
+}
+
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.sidebar header {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.sidebar h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.asset-search input {
+  width: 100%;
+  padding: 0.65rem 0.75rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(158, 203, 255, 0.45);
+  background: rgba(18, 32, 52, 0.75);
+  color: inherit;
+}
+
+.asset-list {
+  flex: 1;
+  background: rgba(9, 18, 29, 0.85);
+  border-radius: 1.25rem;
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  padding: 0.75rem;
+  display: grid;
+  gap: 0.5rem;
+  overflow: auto;
+}
+
+.asset-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  padding: 0.65rem 0.75rem;
+  border-radius: 0.85rem;
+  border: 1px solid transparent;
+  background: rgba(24, 42, 64, 0.65);
+  cursor: pointer;
+  transition: transform 0.12s ease, background 0.12s ease, border 0.12s ease;
+}
+
+.asset-item strong {
+  font-size: 0.95rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.asset-item span {
+  font-size: 0.8rem;
+  color: rgba(207, 227, 255, 0.75);
+}
+
+.asset-item:hover {
+  transform: translateY(-1px);
+  background: rgba(42, 68, 102, 0.75);
+}
+
+.asset-item.active {
+  border-color: rgba(94, 142, 255, 0.8);
+  background: rgba(94, 142, 255, 0.25);
+  box-shadow: 0 0 0 1px rgba(94, 142, 255, 0.45);
+}
+
+.editor {
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  gap: 1.25rem;
+}
+
+.editor header {
+  display: grid;
+  gap: 0.75rem;
+  background: rgba(9, 18, 29, 0.85);
+  border-radius: 1.25rem;
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  padding: 1.25rem;
+}
+
+.editor h2 {
+  margin: 0;
+  font-size: 1.4rem;
+}
+
+.field-group {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.75rem;
+}
+
+.field-group label {
+  display: grid;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: rgba(207, 227, 255, 0.75);
+}
+
+.field-group select,
+.field-group input,
+.type-switch button {
+  width: 100%;
+  padding: 0.55rem 0.65rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(158, 203, 255, 0.4);
+  background: rgba(24, 42, 64, 0.7);
+  color: inherit;
+  font-size: 0.95rem;
+}
+
+.type-switch {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.type-switch button {
+  flex: 1;
+  cursor: pointer;
+  background: rgba(24, 42, 64, 0.65);
+  border: 1px solid rgba(158, 203, 255, 0.35);
+  transition: transform 0.12s ease, background 0.12s ease, border 0.12s ease;
+}
+
+.type-switch button.active {
+  background: rgba(94, 142, 255, 0.25);
+  border-color: rgba(94, 142, 255, 0.8);
+  box-shadow: 0 0 0 1px rgba(94, 142, 255, 0.45);
+}
+
+.sheet-panel {
+  display: grid;
+  gap: 1rem;
+  background: rgba(9, 18, 29, 0.85);
+  border-radius: 1.25rem;
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  padding: 1.25rem;
+  overflow: hidden;
+}
+
+.sheet-container {
+  position: relative;
+  display: inline-block;
+  border-radius: 1rem;
+  overflow: hidden;
+  border: 1px solid rgba(94, 142, 255, 0.3);
+  background: rgba(7, 12, 20, 0.9);
+}
+
+.sheet-overlay {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background-image:
+    linear-gradient(rgba(255, 255, 255, 0.1) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.1) 1px, transparent 1px);
+  background-size: var(--tile-size) var(--tile-size);
+}
+
+.sheet-grid {
+  display: grid;
+  position: relative;
+}
+
+.sheet-cell {
+  width: var(--tile-size);
+  height: var(--tile-size);
+  border: none;
+  padding: 0;
+  margin: 0;
+  background-repeat: no-repeat;
+  background-origin: border-box;
+  cursor: pointer;
+  transition: outline 0.12s ease, transform 0.1s ease;
+}
+
+.sheet-cell:hover {
+  transform: translateY(-1px);
+  outline: 2px solid rgba(94, 142, 255, 0.6);
+}
+
+.sheet-cell.active {
+  outline: 2px solid rgba(255, 255, 255, 0.9);
+  box-shadow: inset 0 0 0 2px rgba(94, 142, 255, 0.65);
+}
+
+.slice-selector {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.slice-selector button {
+  padding: 0.4rem 0.65rem;
+  border-radius: 999px;
+  border: 1px solid rgba(158, 203, 255, 0.35);
+  background: rgba(24, 42, 64, 0.65);
+  color: inherit;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: background 0.12s ease, border 0.12s ease;
+}
+
+.slice-selector button.active {
+  background: rgba(94, 142, 255, 0.3);
+  border-color: rgba(94, 142, 255, 0.85);
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: flex-end;
+}
+
+.actions button {
+  border-radius: 0.85rem;
+  padding: 0.75rem 1.2rem;
+  font-weight: 600;
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition: transform 0.12s ease, background 0.12s ease, border 0.12s ease;
+}
+
+.actions .primary {
+  background: linear-gradient(135deg, #73a8ff, #5d7dff);
+  color: #041021;
+  box-shadow: 0 1rem 2.5rem rgba(94, 142, 255, 0.35);
+}
+
+.actions .secondary {
+  background: rgba(24, 42, 64, 0.7);
+  border: 1px solid rgba(158, 203, 255, 0.4);
+  color: inherit;
+}
+
+.actions button:hover {
+  transform: translateY(-1px);
+}
+
+.status {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  font-size: 0.95rem;
+  color: rgba(207, 227, 255, 0.85);
+}
+
+.status span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.summary {
+  background: rgba(9, 18, 29, 0.85);
+  border-radius: 1.25rem;
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  padding: 1.25rem;
+  display: grid;
+  gap: 0.85rem;
+  font-size: 0.9rem;
+}
+
+.summary pre {
+  background: rgba(7, 12, 20, 0.85);
+  border-radius: 1rem;
+  border: 1px solid rgba(94, 142, 255, 0.35);
+  padding: 0.75rem;
+  margin: 0;
+  max-height: 200px;
+  overflow: auto;
+  font-family: "JetBrains Mono", "Fira Code", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-size: 0.8rem;
+  color: #cfe3ff;
+}
+
+@media (max-width: 1100px) {
+  main {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    order: 2;
+  }
+
+  .editor {
+    order: 1;
+  }
+}
+
+@media (max-width: 680px) {
+  body {
+    padding: 1.25rem;
+  }
+
+  .actions {
+    justify-content: center;
+  }
+}

--- a/data/tiles.json
+++ b/data/tiles.json
@@ -1,51 +1,208 @@
 {
-  "tiles": {
-    "grass": {
-      "surface": "grass",
-      "color": "#3ca66b",
-      "collides": false
+  "tilesets": {
+    "terrain": {
+      "label": "Terrain",
+      "src": "assets/dirt.png",
+      "tileSize": 32,
+      "columns": 3,
+      "rows": 6
     },
-    "path": {
-      "surface": "path",
-      "color": "#c89f5d",
-      "collides": false
+    "grass": {
+      "label": "Grass",
+      "src": "assets/grass.png",
+      "tileSize": 32,
+      "columns": 3,
+      "rows": 6
     },
     "water": {
+      "label": "Water",
+      "src": "assets/water.png",
+      "tileSize": 32,
+      "columns": 3,
+      "rows": 6
+    },
+    "long-grass": {
+      "label": "Long Grass",
+      "src": "assets/long-grass.png",
+      "tileSize": 32,
+      "columns": 1,
+      "rows": 1
+    }
+  },
+  "tiles": {
+    "land": {
+      "label": "Land",
+      "category": "base",
+      "surface": "grass",
+      "color": "#3ca66b",
+      "collides": false,
+      "sprite": {
+        "tileset": "terrain",
+        "type": "nine-slice",
+        "frames": {
+          "single": [0, 0],
+          "topLeft": [0, 2],
+          "top": [1, 2],
+          "topRight": [2, 2],
+          "left": [0, 3],
+          "center": [1, 3],
+          "right": [2, 3],
+          "bottomLeft": [0, 4],
+          "bottom": [1, 4],
+          "bottomRight": [2, 4]
+        }
+      }
+    },
+    "sea": {
+      "label": "Sea",
+      "category": "base",
       "surface": "water",
       "color": "#2a6f97",
-      "collides": true
+      "collides": true,
+      "sprite": {
+        "tileset": "water",
+        "type": "single",
+        "frame": [0, 0]
+      }
+    },
+    "grass": {
+      "label": "Grass",
+      "category": "overlay",
+      "surface": "grass",
+      "color": "#3ca66b",
+      "collides": false,
+      "sprite": {
+        "tileset": "grass",
+        "type": "nine-slice",
+        "frames": {
+          "single": [0, 0],
+          "topLeft": [0, 2],
+          "top": [1, 2],
+          "topRight": [2, 2],
+          "left": [0, 3],
+          "center": [1, 3],
+          "right": [2, 3],
+          "bottomLeft": [0, 4],
+          "bottom": [1, 4],
+          "bottomRight": [2, 4]
+        }
+      }
+    },
+    "short-grass": {
+      "label": "Short Grass",
+      "category": "overlay",
+      "surface": "grass",
+      "color": "#3ca66b",
+      "collides": false,
+      "sprite": {
+        "tileset": "grass",
+        "type": "single",
+        "frame": [1, 5]
+      }
+    },
+    "long-grass": {
+      "label": "Long Grass",
+      "category": "overlay",
+      "surface": "grass",
+      "color": "#3ca66b",
+      "collides": false,
+      "sprite": {
+        "tileset": "long-grass",
+        "type": "single",
+        "frame": [0, 0]
+      }
+    },
+    "path": {
+      "label": "Path",
+      "category": "overlay",
+      "surface": "path",
+      "color": "#c89f5d",
+      "collides": false,
+      "sprite": {
+        "tileset": "terrain",
+        "type": "nine-slice",
+        "frames": {
+          "single": [0, 1],
+          "topLeft": [0, 2],
+          "top": [1, 2],
+          "topRight": [2, 2],
+          "left": [0, 3],
+          "center": [1, 3],
+          "right": [2, 3],
+          "bottomLeft": [0, 4],
+          "bottom": [1, 4],
+          "bottomRight": [2, 4]
+        }
+      }
+    },
+    "water": {
+      "label": "Water",
+      "category": "overlay",
+      "surface": "water",
+      "color": "#2a6f97",
+      "collides": true,
+      "sprite": {
+        "tileset": "water",
+        "type": "nine-slice",
+        "frames": {
+          "single": [0, 0],
+          "topLeft": [0, 2],
+          "top": [1, 2],
+          "topRight": [2, 2],
+          "left": [0, 3],
+          "center": [1, 3],
+          "right": [2, 3],
+          "bottomLeft": [0, 4],
+          "bottom": [1, 4],
+          "bottomRight": [2, 4]
+        }
+      }
     },
     "house": {
+      "label": "House",
+      "category": "building",
       "surface": "grass",
       "color": "#f1ede0",
       "collides": true
     },
     "dog-groomers": {
+      "label": "Dog Groomers",
+      "category": "building",
       "surface": "grass",
       "color": "#9f7aea",
       "collides": true
     },
     "dog-training": {
+      "label": "Dog Training",
+      "category": "building",
       "surface": "grass",
       "color": "#f4a261",
       "collides": true
     },
     "dog-show": {
+      "label": "Dog Show",
+      "category": "building",
       "surface": "grass",
       "color": "#e9d8fd",
       "collides": true
     },
     "pet-shop": {
+      "label": "Pet Shop",
+      "category": "building",
       "surface": "grass",
       "color": "#f6ad55",
       "collides": true
     },
     "sign": {
+      "label": "Sign",
+      "category": "special",
       "surface": "grass",
       "color": "#f6c177",
       "collides": false
     },
     "vets": {
+      "label": "Vets",
+      "category": "building",
       "surface": "grass",
       "color": "#fc8181",
       "collides": true

--- a/js/data/tile-metadata.js
+++ b/js/data/tile-metadata.js
@@ -1,0 +1,21 @@
+export async function loadTileMetadata() {
+  const url = new URL("../../data/tiles.json", import.meta.url);
+  const response = await fetch(url.href, { cache: "no-store" });
+  if (!response.ok) {
+    throw new Error(`Failed to load tile metadata: ${response.status} ${response.statusText}`);
+  }
+  return response.json();
+}
+
+export const NINE_SLICE_KEYS = [
+  "single",
+  "topLeft",
+  "top",
+  "topRight",
+  "left",
+  "center",
+  "right",
+  "bottomLeft",
+  "bottom",
+  "bottomRight"
+];

--- a/js/sprite-picker.js
+++ b/js/sprite-picker.js
@@ -1,0 +1,418 @@
+import { loadTileMetadata, NINE_SLICE_KEYS } from "./data/tile-metadata.js";
+
+const assetList = document.getElementById("assetList");
+const assetSearch = document.getElementById("assetSearch");
+const assetTitle = document.getElementById("assetTitle");
+const assetSubtitle = document.getElementById("assetSubtitle");
+const tilesetSelect = document.getElementById("tilesetSelect");
+const typeButtons = Array.from(document.querySelectorAll(".type-switch button"));
+const sliceSelector = document.getElementById("sliceSelector");
+const sheetContainer = document.getElementById("sheetContainer");
+const sheetGrid = document.getElementById("sheetGrid");
+const sheetPlaceholder = document.getElementById("sheetPlaceholder");
+const statusMessage = document.getElementById("statusMessage");
+const assignmentSummary = document.getElementById("assignmentSummary");
+const jsonPreview = document.getElementById("jsonPreview");
+const downloadButton = document.getElementById("downloadButton");
+const copyButton = document.getElementById("copyButton");
+const resetButton = document.getElementById("resetButton");
+
+const state = {
+  metadata: null,
+  original: null,
+  activeTileId: null,
+  selectedSlice: "center",
+  dirty: false
+};
+
+function cloneMetadata(metadata) {
+  return JSON.parse(JSON.stringify(metadata));
+}
+
+function formatLabel(tileId, tile) {
+  const label = tile?.label || tileId;
+  return label.charAt(0).toUpperCase() + label.slice(1);
+}
+
+function formatCategory(category) {
+  if (!category) return "";
+  return category.replace(/-/g, " ");
+}
+
+function getTilesSorted(metadata) {
+  const entries = Object.entries(metadata.tiles || {});
+  return entries
+    .map(([id, tile]) => ({ id, tile }))
+    .sort((a, b) => {
+      const categoryA = a.tile.category || "";
+      const categoryB = b.tile.category || "";
+      if (categoryA !== categoryB) {
+        return categoryA.localeCompare(categoryB);
+      }
+      const labelA = a.tile.label || a.id;
+      const labelB = b.tile.label || b.id;
+      return labelA.localeCompare(labelB);
+    });
+}
+
+function ensureSprite(tile) {
+  if (!tile.sprite) {
+    tile.sprite = { type: "none" };
+  }
+  if (!tile.sprite.type) {
+    tile.sprite.type = tile.sprite.frame ? "single" : "none";
+  }
+  if (tile.sprite.type === "nine-slice") {
+    if (!tile.sprite.frames || typeof tile.sprite.frames !== "object") {
+      tile.sprite.frames = {};
+    }
+    for (const key of NINE_SLICE_KEYS) {
+      if (!Array.isArray(tile.sprite.frames[key])) {
+        tile.sprite.frames[key] = [0, 0];
+      }
+    }
+  } else if (tile.sprite.type === "single") {
+    if (!Array.isArray(tile.sprite.frame)) {
+      tile.sprite.frame = [0, 0];
+    }
+  }
+  return tile.sprite;
+}
+
+function selectAsset(tileId) {
+  state.activeTileId = tileId;
+  state.selectedSlice = "center";
+  const tile = state.metadata.tiles[tileId];
+  const label = formatLabel(tileId, tile);
+  assetTitle.textContent = label;
+  assetSubtitle.textContent = `${formatCategory(tile.category)} • ${tile.surface || "no surface"}`.trim();
+  ensureSprite(tile);
+  updateTypeButtons(tile.sprite.type);
+  populateTilesetSelect(tile);
+  updateSliceSelector(tile);
+  renderSheet(tile);
+  updateSummary();
+  updateJsonPreview();
+  updateStatus(`Ready to edit ${label}.`);
+}
+
+function updateTypeButtons(type) {
+  typeButtons.forEach((button) => {
+    button.disabled = !state.activeTileId;
+    button.classList.toggle("active", button.dataset.type === type);
+  });
+}
+
+function populateTilesetSelect(tile) {
+  const tilesets = state.metadata.tilesets || {};
+  tilesetSelect.innerHTML = "";
+  const entries = Object.entries(tilesets);
+  entries.forEach(([key, info]) => {
+    const option = document.createElement("option");
+    option.value = key;
+    option.textContent = info.label ? `${info.label} (${key})` : key;
+    tilesetSelect.appendChild(option);
+  });
+  if (!tile.sprite.tileset && entries.length) {
+    tile.sprite.tileset = entries[0][0];
+  }
+  const disableSelect = !state.activeTileId || tile.sprite.type === "none" || !entries.length;
+  tilesetSelect.disabled = disableSelect;
+  if (tile.sprite.tileset) {
+    tilesetSelect.value = tile.sprite.tileset;
+  }
+}
+
+function updateSliceSelector(tile) {
+  if (tile.sprite.type !== "nine-slice") {
+    sliceSelector.hidden = true;
+    sliceSelector.innerHTML = "";
+    return;
+  }
+  sliceSelector.hidden = false;
+  sliceSelector.innerHTML = "";
+  NINE_SLICE_KEYS.forEach((key) => {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.textContent = key.replace(/([A-Z])/g, " $1").trim();
+    button.classList.toggle("active", key === state.selectedSlice);
+    button.addEventListener("click", () => {
+      state.selectedSlice = key;
+      updateSliceSelector(tile);
+      renderSheet(tile);
+      updateSummary();
+    });
+    sliceSelector.appendChild(button);
+  });
+}
+
+function getActiveFrame(tile) {
+  const sprite = tile.sprite;
+  if (sprite.type === "single") {
+    return sprite.frame;
+  }
+  if (sprite.type === "nine-slice") {
+    return sprite.frames?.[state.selectedSlice];
+  }
+  return null;
+}
+
+function renderSheet(tile) {
+  if (tile.sprite.type === "none") {
+    sheetContainer.hidden = true;
+    sheetPlaceholder.hidden = false;
+    sheetPlaceholder.textContent = "Sprite disabled for this tile.";
+    sheetGrid.innerHTML = "";
+    return;
+  }
+
+  const tilesetId = tile.sprite.tileset;
+  const tileset = tilesetId ? state.metadata.tilesets?.[tilesetId] : null;
+  if (!tileset) {
+    sheetContainer.hidden = true;
+    sheetPlaceholder.hidden = false;
+    sheetPlaceholder.textContent = "Choose a tileset to display its sprite sheet.";
+    sheetGrid.innerHTML = "";
+    return;
+  }
+
+  const tileSize = tileset.tileSize || 32;
+  const columns = tileset.columns || 1;
+  const rows = tileset.rows || 1;
+
+  sheetContainer.hidden = false;
+  sheetPlaceholder.hidden = true;
+  sheetGrid.style.setProperty("--tile-size", `${tileSize}px`);
+  sheetGrid.style.gridTemplateColumns = `repeat(${columns}, ${tileSize}px)`;
+  sheetGrid.style.gridTemplateRows = `repeat(${rows}, ${tileSize}px)`;
+  sheetGrid.innerHTML = "";
+
+  const activeFrame = getActiveFrame(tile);
+
+  for (let row = 0; row < rows; row++) {
+    for (let col = 0; col < columns; col++) {
+      const button = document.createElement("button");
+      button.type = "button";
+      button.className = "sheet-cell";
+      button.dataset.col = col;
+      button.dataset.row = row;
+      button.style.setProperty("--tile-size", `${tileSize}px`);
+      button.style.backgroundImage = `url(${tileset.src})`;
+      button.style.backgroundSize = `${columns * tileSize}px ${rows * tileSize}px`;
+      button.style.backgroundPosition = `${-col * tileSize}px ${-row * tileSize}px`;
+      if (Array.isArray(activeFrame) && activeFrame[0] === col && activeFrame[1] === row) {
+        button.classList.add("active");
+      }
+      button.addEventListener("click", () => {
+        applyFrame(tile, [col, row]);
+      });
+      sheetGrid.appendChild(button);
+    }
+  }
+}
+
+function applyFrame(tile, frame) {
+  ensureSprite(tile);
+  const sprite = tile.sprite;
+  if (!sprite.tileset) {
+    sprite.tileset = tilesetSelect.value;
+  }
+  if (sprite.type === "nine-slice") {
+    sprite.frames[state.selectedSlice] = frame;
+  } else if (sprite.type === "single") {
+    sprite.frame = frame;
+  }
+  state.dirty = true;
+  renderSheet(tile);
+  updateSummary();
+  updateJsonPreview();
+  const label = formatLabel(state.activeTileId, tile);
+  const sliceLabel = sprite.type === "nine-slice" ? ` (${state.selectedSlice})` : "";
+  updateStatus(`Updated ${label}${sliceLabel} to column ${frame[0]}, row ${frame[1]}.`);
+}
+
+function updateSummary() {
+  if (!state.activeTileId) {
+    assignmentSummary.textContent = "";
+    return;
+  }
+  const tile = state.metadata.tiles[state.activeTileId];
+  const sprite = tile.sprite;
+  if (!sprite || sprite.type === "none") {
+    assignmentSummary.textContent = "No sprite assigned.";
+    return;
+  }
+  const tileset = sprite.tileset ? state.metadata.tilesets?.[sprite.tileset] : null;
+  const tilesetLabel = tileset?.label ? `${tileset.label} (${sprite.tileset})` : sprite.tileset || "Unknown";
+  if (sprite.type === "single") {
+    assignmentSummary.textContent = `Tileset: ${tilesetLabel} • Frame: [${sprite.frame.join(", ")}]`;
+  } else if (sprite.type === "nine-slice") {
+    const frame = sprite.frames?.[state.selectedSlice];
+    assignmentSummary.textContent = `Tileset: ${tilesetLabel} • Slice: ${state.selectedSlice} • Frame: [${frame.join(", ")}]`;
+  } else {
+    assignmentSummary.textContent = `Tileset: ${tilesetLabel}`;
+  }
+}
+
+function updateJsonPreview() {
+  jsonPreview.textContent = JSON.stringify(state.metadata.tiles[state.activeTileId] ?? {}, null, 2);
+}
+
+function updateStatus(message) {
+  statusMessage.textContent = message;
+}
+
+function setSpriteType(tile, type) {
+  ensureSprite(tile);
+  tile.sprite.type = type;
+  if (type === "none") {
+    delete tile.sprite.tileset;
+    delete tile.sprite.frame;
+    delete tile.sprite.frames;
+  } else if (type === "single") {
+    tile.sprite.frame = Array.isArray(tile.sprite.frame) ? tile.sprite.frame : [0, 0];
+    if (!tile.sprite.tileset) {
+      const firstTileset = Object.keys(state.metadata.tilesets || {})[0];
+      if (firstTileset) {
+        tile.sprite.tileset = firstTileset;
+      }
+    }
+  } else if (type === "nine-slice") {
+    if (!tile.sprite.tileset) {
+      const firstTileset = Object.keys(state.metadata.tilesets || {})[0];
+      if (firstTileset) {
+        tile.sprite.tileset = firstTileset;
+      }
+    }
+    tile.sprite.frames = tile.sprite.frames || {};
+    for (const key of NINE_SLICE_KEYS) {
+      if (!Array.isArray(tile.sprite.frames[key])) {
+        tile.sprite.frames[key] = [0, 0];
+      }
+    }
+    state.selectedSlice = state.selectedSlice || "center";
+  }
+  updateTypeButtons(type);
+  populateTilesetSelect(tile);
+  updateSliceSelector(tile);
+  renderSheet(tile);
+  updateSummary();
+  updateJsonPreview();
+  state.dirty = true;
+}
+
+function downloadMetadata() {
+  const blob = new Blob([JSON.stringify(state.metadata, null, 2)], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = "tiles.json";
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+  updateStatus("Downloaded updated tiles.json.");
+}
+
+async function copyMetadata() {
+  try {
+    await navigator.clipboard.writeText(JSON.stringify(state.metadata, null, 2));
+    updateStatus("Copied JSON to clipboard.");
+  } catch (error) {
+    updateStatus(`Clipboard unavailable: ${error.message}`);
+  }
+}
+
+function resetMetadata() {
+  if (!state.original) return;
+  state.metadata = cloneMetadata(state.original);
+  state.dirty = false;
+  renderAssetList(assetSearch.value);
+  updateStatus("Reverted changes to original metadata.");
+  if (state.activeTileId) {
+    selectAsset(state.activeTileId);
+  }
+}
+
+function renderAssetList(filterText = "") {
+  assetList.innerHTML = "";
+  const tiles = getTilesSorted(state.metadata);
+  const query = filterText.trim().toLowerCase();
+  tiles
+    .filter(({ id, tile }) => {
+      if (!query) return true;
+      return (
+        id.toLowerCase().includes(query) ||
+        (tile.label && tile.label.toLowerCase().includes(query)) ||
+        (tile.category && tile.category.toLowerCase().includes(query))
+      );
+    })
+    .forEach(({ id, tile }) => {
+      const item = document.createElement("button");
+      item.type = "button";
+      item.className = "asset-item";
+      item.dataset.tileId = id;
+      item.setAttribute("role", "option");
+      item.innerHTML = `<strong>${formatLabel(id, tile)}</strong><span>${formatCategory(tile.category)}</span>`;
+      if (id === state.activeTileId) {
+        item.classList.add("active");
+      }
+      item.addEventListener("click", () => {
+        document.querySelectorAll(".asset-item").forEach((button) => button.classList.remove("active"));
+        item.classList.add("active");
+        selectAsset(id);
+      });
+      assetList.appendChild(item);
+    });
+}
+
+function handleTilesetChange() {
+  if (!state.activeTileId) return;
+  const tile = state.metadata.tiles[state.activeTileId];
+  ensureSprite(tile);
+  tile.sprite.tileset = tilesetSelect.value;
+  state.dirty = true;
+  renderSheet(tile);
+  updateSummary();
+  updateJsonPreview();
+  updateStatus(`Using ${tilesetSelect.value} tileset for ${formatLabel(state.activeTileId, tile)}.`);
+}
+
+tilesetSelect.addEventListener("change", handleTilesetChange);
+typeButtons.forEach((button) => {
+  button.addEventListener("click", () => {
+    if (!state.activeTileId) return;
+    const tile = state.metadata.tiles[state.activeTileId];
+    setSpriteType(tile, button.dataset.type);
+    updateStatus(`Changed sprite type to ${button.dataset.type}.`);
+  });
+});
+assetSearch.addEventListener("input", () => {
+  renderAssetList(assetSearch.value);
+});
+downloadButton.addEventListener("click", downloadMetadata);
+copyButton.addEventListener("click", copyMetadata);
+resetButton.addEventListener("click", resetMetadata);
+
+async function init() {
+  try {
+    const metadata = await loadTileMetadata();
+    state.metadata = cloneMetadata(metadata);
+    state.original = cloneMetadata(metadata);
+    renderAssetList();
+    updateStatus("Loaded tile metadata.");
+    const firstTile = Object.keys(state.metadata.tiles || {})[0];
+    if (firstTile) {
+      const firstButton = assetList.querySelector(".asset-item");
+      if (firstButton) {
+        firstButton.classList.add("active");
+      }
+      selectAsset(firstTile);
+    }
+  } catch (error) {
+    updateStatus(`Failed to load metadata: ${error.message}`);
+    jsonPreview.textContent = error.stack || error.message;
+  }
+}
+
+init();

--- a/spritepicker.html
+++ b/spritepicker.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sprite Picker</title>
+    <link rel="stylesheet" href="css/sprite-picker.css" />
+  </head>
+  <body>
+    <main>
+      <aside class="sidebar">
+        <header>
+          <h1>Sprite Picker</h1>
+          <p>Select a tile to assign sprites from the shared sheets.</p>
+        </header>
+        <label class="asset-search">
+          <input type="search" id="assetSearch" placeholder="Search tiles" aria-label="Search tiles" />
+        </label>
+        <div class="asset-list" id="assetList" role="listbox" aria-label="Available tiles"></div>
+      </aside>
+      <section class="editor" aria-live="polite">
+        <header>
+          <div>
+            <h2 id="assetTitle">Select a tile</h2>
+            <p id="assetSubtitle">Choose an item from the list to begin assigning sprites.</p>
+          </div>
+          <div class="field-group">
+            <label>
+              Tileset
+              <select id="tilesetSelect" aria-label="Select tileset" disabled></select>
+            </label>
+            <label>
+              Sprite Type
+              <div class="type-switch" role="group" aria-label="Sprite type">
+                <button type="button" data-type="none" disabled>None</button>
+                <button type="button" data-type="single" disabled>Single</button>
+                <button type="button" data-type="nine-slice" disabled>Nine-slice</button>
+              </div>
+            </label>
+          </div>
+          <div class="slice-selector" id="sliceSelector" hidden></div>
+        </header>
+        <section class="sheet-panel">
+          <div class="sheet-container" id="sheetContainer" hidden>
+            <div class="sheet-grid" id="sheetGrid" role="grid"></div>
+            <div class="sheet-overlay"></div>
+          </div>
+          <div id="sheetPlaceholder">Choose a tileset to display its sprite sheet.</div>
+        </section>
+        <footer class="summary">
+          <div class="status">
+            <span id="statusMessage">No changes yet.</span>
+            <span id="assignmentSummary"></span>
+          </div>
+          <pre id="jsonPreview" aria-label="Sprite assignment preview"></pre>
+          <div class="actions">
+            <button class="secondary" type="button" id="resetButton">Reset</button>
+            <button class="primary" type="button" id="downloadButton">Download JSON</button>
+            <button class="secondary" type="button" id="copyButton">Copy JSON</button>
+          </div>
+        </footer>
+      </section>
+    </main>
+    <script type="module" src="js/sprite-picker.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a dedicated spritepicker.html with a styled workspace for mapping sprites to tiles
- introduce a shared tile metadata loader and extend tiles.json with tileset and sprite assignments
- refactor the level designer to consume the shared metadata so palette previews follow sprite mappings

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68d9a56633b8832fa16f6199baa7d68f