### PR TITLE
Correct tile metadata for level designer sprites

### DIFF
--- a/data/tiles.json
+++ b/data/tiles.json
@@ -31,137 +31,6 @@
   },
   "tiles": {
     "land": {
-  "label": "Land",
-  "category": "base",
-  "surface": "grass",
-  "color": "#3ca66b",
-  "collides": false,
-  "sprite": {
-    "tileset": "terrain",
-    "type": "nine-slice",
-    "frames": {
-      "single": [
-        0,
-        0
-      ],
-      "topLeft": [
-        0,
-        2
-      ],
-      "top": [
-        1,
-        2
-      ],
-      "topRight": [
-        2,
-        2
-      ],
-      "left": [
-        0,
-        3
-      ],
-      "center": [
-        1,
-        3
-      ],
-      "right": [
-        2,
-        3
-      ],
-      "bottomLeft": [
-        0,
-        4
-      ],
-      "bottom": [
-        1,
-        4
-      ],
-      "bottomRight": [
-        2,
-        4
-      ]
-    }
-  }
-},
-    "sea": {
-  "tilesets": {
-    "terrain": {
-      "label": "Terrain",
-      "src": "assets/dirt.png",
-      "tileSize": 32,
-      "columns": 3,
-      "rows": 6
-    },
-    "grass": {
-  "label": "Grass",
-  "category": "overlay",
-  "surface": "grass",
-  "color": "#3ca66b",
-  "collides": false,
-  "sprite": {
-    "tileset": "grass",
-    "type": "nine-slice",
-    "frames": {
-      "single": [
-        0,
-        0
-      ],
-      "topLeft": [
-        0,
-        2
-      ],
-      "top": [
-        1,
-        2
-      ],
-      "topRight": [
-        2,
-        2
-      ],
-      "left": [
-        0,
-        3
-      ],
-      "center": [
-        1,
-        3
-      ],
-      "right": [
-        2,
-        3
-      ],
-      "bottomLeft": [
-        0,
-        4
-      ],
-      "bottom": [
-        1,
-        4
-      ],
-      "bottomRight": [
-        2,
-        4
-      ]
-    }
-  }
-},
-    "water": {
-      "label": "Water",
-      "src": "assets/water.png",
-      "tileSize": 32,
-      "columns": 3,
-      "rows": 6
-    },
-    "long-grass": {
-      "label": "Long Grass",
-      "src": "assets/long-grass.png",
-      "tileSize": 32,
-      "columns": 1,
-      "rows": 1
-    }
-  },
-  "tiles": {
-    "land": {
       "label": "Land",
       "category": "base",
       "surface": "grass",
@@ -332,53 +201,11 @@
       "collides": false,
       "sprite": {
         "tileset": "grass",
-        "type": "nine-slice",
+        "type": "single",
         "frame": [
           1,
           5
-        ],
-        "frames": {
-          "single": [
-            0,
-            0
-          ],
-          "topLeft": [
-            0,
-            2
-          ],
-          "top": [
-            1,
-            2
-          ],
-          "topRight": [
-            2,
-            2
-          ],
-          "left": [
-            0,
-            3
-          ],
-          "center": [
-            0,
-            5
-          ],
-          "right": [
-            2,
-            3
-          ],
-          "bottomLeft": [
-            0,
-            4
-          ],
-          "bottom": [
-            1,
-            4
-          ],
-          "bottomRight": [
-            2,
-            4
-          ]
-        }
+        ]
       }
     },
     "long-grass": {
@@ -461,7 +288,7 @@
         "frames": {
           "single": [
             0,
-            1
+            0
           ],
           "topLeft": [
             0,
@@ -481,7 +308,7 @@
           ],
           "center": [
             1,
-            5
+            3
           ],
           "right": [
             2,
@@ -499,154 +326,6 @@
             2,
             4
           ]
-        }
-      }
-    },
-    "house": {
-      "label": "House",
-      "category": "building",
-      "surface": "grass",
-      "color": "#f1ede0",
-      "collides": true
-    },
-    "dog-groomers": {
-      "label": "Dog Groomers",
-      "category": "building",
-      "surface": "grass",
-      "color": "#9f7aea",
-      "collides": true
-    },
-    "dog-training": {
-      "label": "Dog Training",
-      "category": "building",
-      "surface": "grass",
-      "color": "#f4a261",
-      "collides": true
-    },
-    "dog-show": {
-      "label": "Dog Show",
-      "category": "building",
-      "surface": "grass",
-      "color": "#e9d8fd",
-      "collides": true
-    },
-    "pet-shop": {
-      "label": "Pet Shop",
-      "category": "building",
-      "surface": "grass",
-      "color": "#f6ad55",
-      "collides": true
-    },
-    "sign": {
-      "label": "Sign",
-      "category": "special",
-      "surface": "grass",
-      "color": "#f6c177",
-      "collides": false,
-      "sprite": {
-        "type": "none",
-        "tileset": "terrain"
-      }
-    },
-    "vets": {
-      "label": "Vets",
-      "category": "building",
-      "surface": "grass",
-      "color": "#fc8181",
-      "collides": true
-    }
-  }
-},
-    "grass": {
-      "label": "Grass",
-      "category": "overlay",
-      "surface": "grass",
-      "color": "#3ca66b",
-      "collides": false,
-      "sprite": {
-        "tileset": "grass",
-        "type": "nine-slice",
-        "frames": {
-          "single": [0, 0],
-          "topLeft": [0, 2],
-          "top": [1, 2],
-          "topRight": [2, 2],
-          "left": [0, 3],
-          "center": [1, 3],
-          "right": [2, 3],
-          "bottomLeft": [0, 4],
-          "bottom": [1, 4],
-          "bottomRight": [2, 4]
-        }
-      }
-    },
-    "short-grass": {
-      "label": "Short Grass",
-      "category": "overlay",
-      "surface": "grass",
-      "color": "#3ca66b",
-      "collides": false,
-      "sprite": {
-        "tileset": "grass",
-        "type": "single",
-        "frame": [1, 5]
-      }
-    },
-    "long-grass": {
-      "label": "Long Grass",
-      "category": "overlay",
-      "surface": "grass",
-      "color": "#3ca66b",
-      "collides": false,
-      "sprite": {
-        "tileset": "long-grass",
-        "type": "single",
-        "frame": [0, 0]
-      }
-    },
-    "path": {
-      "label": "Path",
-      "category": "overlay",
-      "surface": "path",
-      "color": "#c89f5d",
-      "collides": false,
-      "sprite": {
-        "tileset": "terrain",
-        "type": "nine-slice",
-        "frames": {
-          "single": [0, 1],
-          "topLeft": [0, 2],
-          "top": [1, 2],
-          "topRight": [2, 2],
-          "left": [0, 3],
-          "center": [1, 3],
-          "right": [2, 3],
-          "bottomLeft": [0, 4],
-          "bottom": [1, 4],
-          "bottomRight": [2, 4]
-        }
-      }
-    },
-    "water": {
-      "label": "Water",
-      "category": "overlay",
-      "surface": "water",
-      "color": "#2a6f97",
-      "collides": true,
-      "sprite": {
-        "tileset": "water",
-        "type": "nine-slice",
-        "frames": {
-          "single": [0, 0],
-          "topLeft": [0, 2],
-          "top": [1, 2],
-          "topRight": [2, 2],
-          "left": [0, 3],
-          "center": [1, 3],
-          "right": [2, 3],
-          "bottomLeft": [0, 4],
-          "bottom": [1, 4],
-          "bottomRight": [2, 4]
         }
       }
     },


### PR DESCRIPTION
## Summary
- repair the malformed `sea` entry in `data/tiles.json` so each tile keeps its sprite configuration at the top level
- ensure all sprite definitions (land, grass, path, water, etc.) remain accessible to the level designer

## Testing
- `node - <<'NODE'
const fs = await import('fs/promises');
const { createDesignModes } = await import('./js/leveldesigner/modes.js');
const metadata = JSON.parse(await fs.readFile('data/tiles.json', 'utf8'));
const config = createDesignModes(metadata).town.buildTileLayers({
  state: [
    [{ base: 'land', overlay: 'grass' }, { base: 'land', overlay: 'grass' }],
    [{ base: 'land', overlay: 'grass' }, { base: 'land', overlay: 'grass' }]
  ],
  gridSize: 2,
  tile: { base: 'land', overlay: 'grass' },
  x: 0,
  y: 0
});
console.log(config);
NODE`
- `node - <<'NODE'
const fs = await import('fs/promises');
const { createDesignModes } = await import('./js/leveldesigner/modes.js');
const metadata = JSON.parse(await fs.readFile('data/tiles.json', 'utf8'));
const layers = createDesignModes(metadata).town.buildTileLayers({
  state: [
    [{ base: 'sea', overlay: 'none' }, { base: 'sea', overlay: 'none' }],
    [{ base: 'sea', overlay: 'none' }, { base: 'sea', overlay: 'none' }]
  ],
  gridSize: 2,
  tile: { base: 'sea', overlay: 'none' },
  x: 0,
  y: 0
});
console.log(layers);
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68d9ac858114832f9d7a66966a3b6ea1