### PR TITLE
Fix right-click dragging for sea tiles

### DIFF
--- a/js/leveldesigner/main.js
+++ b/js/leveldesigner/main.js
@@ -36,6 +36,7 @@ let currentTool = null;
 let brushDimension = BRUSH_OPTIONS[0];
 let currentSignText = '';
 let mouseDown = false;
+let activePointerButton = 0;
 
 function ensureSnapshot(mode) {
   if (!modeSnapshots.has(mode.id)) {
@@ -167,7 +168,9 @@ function updateStatus(message) {
 function handlePointerDown(event) {
   if (!currentMode) return;
   event.preventDefault();
-  const toolId = event.button === 2 ? 'sea' : currentTool;
+  activePointerButton = event.button;
+  const isRightClick = event.button === 2;
+  const toolId = isRightClick ? 'sea' : currentTool;
   const x = Number(event.currentTarget.dataset.x);
   const y = Number(event.currentTarget.dataset.y);
   mouseDown = true;
@@ -188,7 +191,8 @@ function handlePointerDown(event) {
 
 function handlePointerEnter(event) {
   if (!mouseDown || !currentMode) return;
-  const toolId = event.buttons === 2 ? 'sea' : currentTool;
+  const isRightClick = event.buttons ? (event.buttons & 2) === 2 : activePointerButton === 2;
+  const toolId = isRightClick ? 'sea' : currentTool;
   const x = Number(event.currentTarget.dataset.x);
   const y = Number(event.currentTarget.dataset.y);
   applyBrush({
@@ -207,6 +211,7 @@ function handlePointerEnter(event) {
 
 function handlePointerUp() {
   mouseDown = false;
+  activePointerButton = 0;
 }
 
 function resizeGrid() {


### PR DESCRIPTION
## Summary
- track the active pointer button while painting in the level designer
- ensure right-click drags continue to apply the sea brush when moving between tiles
- reset pointer state on pointer up to avoid incorrect tool reuse

## Testing
- Manual check: right-click drag converts tiles back to sea in leveldesigner.html

------
https://chatgpt.com/codex/tasks/task_e_68d9c8fd5dc0832f863563140170c8fa