### PR TITLE
Fix level designer brush centering and sea painting

### DIFF
--- a/js/leveldesigner/modes.js
+++ b/js/leveldesigner/modes.js
@@ -164,7 +164,7 @@ function createTownMode(tileMetadata) {
       'pet-shop',
       'sign'
     ]),
-    brushTools: new Set(['land', 'grass', 'short-grass', 'long-grass']),
+    brushTools: new Set(['land', 'sea', 'grass', 'short-grass', 'long-grass']),
     landOnlyTools: new Set([
       'grass',
       'short-grass',
@@ -335,7 +335,7 @@ function createInteriorMode() {
     overlayEmoji,
     baseTypes: new Set(['sea', 'land']),
     overlayTypes: new Set(['none', 'carpet', 'tile-inlay', 'counter', 'kennel', 'sign']),
-    brushTools: new Set(['land', 'carpet', 'tile-inlay']),
+    brushTools: new Set(['land', 'sea', 'carpet', 'tile-inlay']),
     landOnlyTools: new Set(['carpet', 'tile-inlay', 'counter', 'kennel', 'sign']),
     buildingTools: new Set(),
     buildingSize: 3,

--- a/js/leveldesigner/tools.js
+++ b/js/leveldesigner/tools.js
@@ -109,8 +109,9 @@ function applyBrush({
   signText
 }) {
   const span = mode.brushTools.has(toolId) ? Math.min(brushSize, gridSize) : 1;
-  const startX = Math.max(0, Math.min(x, gridSize - span));
-  const startY = Math.max(0, Math.min(y, gridSize - span));
+  const half = Math.floor(span / 2);
+  const startX = Math.max(0, Math.min(x - half, gridSize - span));
+  const startY = Math.max(0, Math.min(y - half, gridSize - span));
   let needsBase = false;
 
   for (let by = 0; by < span; by++) {


### PR DESCRIPTION
## Summary
- center the brush footprint around the cursor so larger brushes cover the intended area
- allow the sea tool to use larger brush sizes in both town and interior modes for consistent clearing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9cad091a4832f95fa93d5f0f71cb7