### PR TITLE
Fix shoreline rendering at map edges

### DIFF
--- a/js/leveldesigner/modes.js
+++ b/js/leveldesigner/modes.js
@@ -287,8 +287,13 @@ function createTownMode(tileMetadata) {
   };
 
   mode.buildTileLayers = ({ state, gridSize, tile, x, y }) => {
-    const baseMatch = (nx, ny) =>
-      ny >= 0 && ny < gridSize && nx >= 0 && nx < gridSize && state[ny][nx].base === tile.base;
+    const defaultBase = mode.defaultTile().base;
+    const baseMatch = (nx, ny) => {
+      if (ny < 0 || ny >= gridSize || nx < 0 || nx >= gridSize) {
+        return tile.base === defaultBase;
+      }
+      return state[ny][nx].base === tile.base;
+    };
     const overlayMatch = (nx, ny, overlay) =>
       ny >= 0 && ny < gridSize && nx >= 0 && nx < gridSize && state[ny][nx].overlay === overlay;
 


### PR DESCRIPTION
## Summary
- treat tiles outside the grid as the default base when determining nine-slice frames
- stop the level designer from drawing coastline edges around the starting sea tiles

## Testing
- Manual verification in the browser

------
https://chatgpt.com/codex/tasks/task_e_68d9ce44ce30832f80e1f78e8044c354